### PR TITLE
fix: correct assign to binary interface value

### DIFF
--- a/_test/interface9.go
+++ b/_test/interface9.go
@@ -1,0 +1,18 @@
+package main
+
+import "fmt"
+
+type Int int
+
+func (I Int) String() string {
+	return "foo"
+}
+
+func main() {
+	var i Int
+	var st fmt.Stringer = i
+	fmt.Println(st.String())
+}
+
+// Output:
+// foo

--- a/interp/run.go
+++ b/interp/run.go
@@ -223,6 +223,8 @@ func assign(n *node) {
 		switch {
 		case dest.typ.cat == interfaceT:
 			svalue[i] = genValueInterface(src)
+		case dest.typ.cat == valueT && dest.typ.rtype.Kind() == reflect.Interface:
+			svalue[i] = genInterfaceWrapper(src, dest.typ.rtype)
 		case dest.typ.cat == valueT && src.typ.cat == funcT:
 			svalue[i] = genFunctionWrapper(src)
 		case src.kind == basicLit && src.val == nil:


### PR DESCRIPTION
If assign destination type is a binary interface, get source value from
interface wrapper.

Fix #251