### PR TITLE
interp/build: improve Go version handling.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -44,7 +44,6 @@
     path = "cmd/goexports/goexports.go"
     text = "SA1019: importer.For is deprecated: use ForCompiler, which populates a FileSet with the positions of objects created by the importer."
 
-  # structcheck false-positive
   [[issues.exclude-rules]]
-    path = "interp/interp.go"
-    text = "`(astDot|cfgDot|noRun)` is unused"
+    path = "interp/.+_test\\.go"
+    linters = ["goconst"]

--- a/interp/build.go
+++ b/interp/build.go
@@ -2,6 +2,7 @@ package interp
 
 import (
 	"go/parser"
+	"math"
 	"path"
 	"runtime"
 	"strconv"
@@ -87,12 +88,25 @@ func buildTagOk(s string) (r bool) {
 
 // goNumVersion returns the go minor version number
 func goNumVersion(version string) int {
+	if version == "devel" {
+		return math.MaxInt16
+	}
+
 	v := strings.Split(version, ".")
 	if len(v) < 2 {
 		panic("unsupported Go version: " + version)
 	}
 
-	n, err := strconv.Atoi(v[1])
+	minor := v[1]
+	index := strings.Index(minor, "beta")
+	if index < 0 {
+		index = strings.Index(minor, "rc")
+	}
+	if index > 0 {
+		minor = minor[:index]
+	}
+
+	n, err := strconv.Atoi(minor)
 	if err != nil {
 		panic("unsupported Go version: " + version)
 	}

--- a/interp/build.go
+++ b/interp/build.go
@@ -57,7 +57,7 @@ func buildOptionOk(tag string) bool {
 var (
 	goos      = runtime.GOOS
 	goarch    = runtime.GOARCH
-	goversion = goNumVersion()
+	goversion = goNumVersion(runtime.Version())
 )
 
 // buildTagOk returns true if a build tag matches, false otherwise
@@ -86,9 +86,16 @@ func buildTagOk(s string) (r bool) {
 }
 
 // goNumVersion returns the go minor version number
-func goNumVersion() int {
-	v := strings.Split(runtime.Version(), ".")
-	n, _ := strconv.Atoi(v[1])
+func goNumVersion(version string) int {
+	v := strings.Split(version, ".")
+	if len(v) < 2 {
+		panic("unsupported Go version: " + version)
+	}
+
+	n, err := strconv.Atoi(v[1])
+	if err != nil {
+		panic("unsupported Go version: " + version)
+	}
 	return n
 }
 

--- a/interp/build.go
+++ b/interp/build.go
@@ -1,8 +1,8 @@
 package interp
 
 import (
+	"go/build"
 	"go/parser"
-	"math"
 	"path"
 	"runtime"
 	"strconv"
@@ -58,7 +58,7 @@ func buildOptionOk(tag string) bool {
 var (
 	goos      = runtime.GOOS
 	goarch    = runtime.GOARCH
-	goversion = goNumVersion(runtime.Version())
+	goversion = goMinorVersion(build.Default)
 )
 
 // buildTagOk returns true if a build tag matches, false otherwise
@@ -86,31 +86,20 @@ func buildTagOk(s string) (r bool) {
 	return
 }
 
-// goNumVersion returns the go minor version number
-func goNumVersion(version string) int {
-	if version == "devel" {
-		return math.MaxInt16
-	}
+// goMinorVersion returns the go minor version number
+func goMinorVersion(ctx build.Context) int {
+	current := ctx.ReleaseTags[len(ctx.ReleaseTags)-1]
 
-	v := strings.Split(version, ".")
+	v := strings.Split(current, ".")
 	if len(v) < 2 {
-		panic("unsupported Go version: " + version)
+		panic("unsupported Go version: " + current)
 	}
 
-	minor := v[1]
-	index := strings.Index(minor, "beta")
-	if index < 0 {
-		index = strings.Index(minor, "rc")
-	}
-	if index > 0 {
-		minor = minor[:index]
-	}
-
-	n, err := strconv.Atoi(minor)
+	m, err := strconv.Atoi(v[1])
 	if err != nil {
-		panic("unsupported Go version: " + version)
+		panic("unsupported Go version: " + current)
 	}
-	return n
+	return m
 }
 
 // skipFile returns true if file should be skipped

--- a/interp/build_test.go
+++ b/interp/build_test.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"math"
 	"testing"
 )
 
@@ -18,9 +19,44 @@ func TestBuildTag(t *testing.T) {
 	tests := []testBuild{
 		{"// +build linux", true},
 		{"// +build windows", false},
+		{"// +build go1.9", true},
 		{"// +build go1.11", true},
-		{"// +build !go1.12", true},
 		{"// +build go1.12", false},
+		{"// +build !go1.10", false},
+		{"// +build !go1.12", true},
+		{"// +build ignore", false},
+		{"// +build linux,amd64", true},
+		{"// +build linux,i386", false},
+		{"// +build linux,i386 go1.11", true},
+		{"// +build linux\n// +build amd64", true},
+		{"// +build linux\n\n\n// +build amd64", true},
+		{"// +build linux\n// +build i386", false},
+	}
+
+	i := New(Options{})
+	for _, test := range tests {
+		test := test
+		src := test.src + "\npackage x"
+		t.Run(test.src, func(t *testing.T) {
+			if r := i.buildOk("", src); r != test.res {
+				t.Errorf("got %v, want %v", r, test.res)
+			}
+		})
+	}
+}
+
+func TestBuildTagDevel(t *testing.T) {
+	// Assume a specific OS, arch and go version no matter the real underlying system
+	oo, oa, ov := goos, goarch, goversion
+	goos, goarch, goversion = "linux", "amd64", math.MaxInt16
+	defer func() { goos, goarch, goversion = oo, oa, ov }()
+
+	tests := []testBuild{
+		{"// +build linux", true},
+		{"// +build windows", false},
+		{"// +build go1.11", true},
+		{"// +build !go1.12", false},
+		{"// +build go1.12", true},
 		{"// +build !go1.10", false},
 		{"// +build go1.9", true},
 		{"// +build ignore", false},
@@ -36,7 +72,7 @@ func TestBuildTag(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		src := test.src + "\npackage x"
-		t.Run("", func(t *testing.T) {
+		t.Run(test.src, func(t *testing.T) {
 			if r := i.buildOk("", src); r != test.res {
 				t.Errorf("got %v, want %v", r, test.res)
 			}
@@ -68,6 +104,29 @@ func TestBuildFile(t *testing.T) {
 		t.Run(test.src, func(t *testing.T) {
 			if r := skipFile(test.src); r != test.res {
 				t.Errorf("got %v, want %v", r, test.res)
+			}
+		})
+	}
+}
+
+func Test_goNumVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected int
+	}{
+		{version: "go1.12", expected: 12},
+		{version: "go1.13beta1", expected: 13},
+		{version: "go1.13rc1", expected: 13},
+		{version: "devel", expected: math.MaxInt16},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.version, func(t *testing.T) {
+			minor := goNumVersion(test.version)
+
+			if minor != test.expected {
+				t.Errorf("got %v, want %v", minor, test.expected)
 			}
 		})
 	}

--- a/interp/build_test.go
+++ b/interp/build_test.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"go/build"
 	"math"
 	"testing"
 )
@@ -109,21 +110,32 @@ func TestBuildFile(t *testing.T) {
 	}
 }
 
-func Test_goNumVersion(t *testing.T) {
+func Test_goMinorVersion(t *testing.T) {
 	tests := []struct {
-		version  string
+		desc     string
+		context  build.Context
 		expected int
 	}{
-		{version: "go1.12", expected: 12},
-		{version: "go1.13beta1", expected: 13},
-		{version: "go1.13rc1", expected: 13},
-		{version: "devel", expected: math.MaxInt16},
+		{
+			desc: "stable",
+			context: build.Context{ReleaseTags: []string{
+				"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7", "go1.8", "go1.9", "go1.10", "go1.11", "go1.12",
+			}},
+			expected: 12,
+		},
+		{
+			desc: "devel/beta/rc",
+			context: build.Context{ReleaseTags: []string{
+				"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7", "go1.8", "go1.9", "go1.10", "go1.11", "go1.12", "go1.13",
+			}},
+			expected: 13,
+		},
 	}
 
 	for _, test := range tests {
 		test := test
-		t.Run(test.version, func(t *testing.T) {
-			minor := goNumVersion(test.version)
+		t.Run(test.desc, func(t *testing.T) {
+			minor := goMinorVersion(test.context)
 
 			if minor != test.expected {
 				t.Errorf("got %v, want %v", minor, test.expected)

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -1,3 +1,5 @@
+// +build go1.11,!go1.13
+
 package stdlib
 
 import "reflect"

--- a/stdlib/syscall/syscall.go
+++ b/stdlib/syscall/syscall.go
@@ -1,3 +1,5 @@
+// +build go1.11,!go1.13
+
 package syscall
 
 import "reflect"

--- a/stdlib/unsafe/unsafe.go
+++ b/stdlib/unsafe/unsafe.go
@@ -1,3 +1,5 @@
+// +build go1.11,!go1.13
+
 package unsafe
 
 import "reflect"


### PR DESCRIPTION
Display a better message when a version is not supported.

Allow to use `devel`, `beta`, and `rc` versions.

Related to #304, #309