### PR TITLE
fix: support 'range' with no index and value assigned

### DIFF
--- a/_test/a30.go
+++ b/_test/a30.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	for range []struct{}{} {
+	}
+	println("ok")
+}
+
+// Output:
+// ok

--- a/_test/a31.go
+++ b/_test/a31.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+	for range []int{0, 1, 2} {
+		print("hello ")
+	}
+	println("")
+}
+
+// Output:
+// hello hello hello

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -696,7 +696,13 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 		case *ast.RangeStmt:
 			// Insert a missing ForRangeStmt for AST correctness
 			n := addChild(&root, anc, pos, forRangeStmt, aNop)
-			st.push(addChild(&root, astNode{n, nod}, pos, rangeStmt, aRange), nod)
+			r := addChild(&root, astNode{n, nod}, pos, rangeStmt, aRange)
+			st.push(r, nod)
+			if a.Key == nil {
+				// range not in an assign expression: insert a "_" key variable to store iteration index
+				k := addChild(&root, astNode{r, nod}, pos, identExpr, aNop)
+				k.ident = "_"
+			}
 
 		case *ast.ReturnStmt:
 			st.push(addChild(&root, anc, pos, returnStmt, aReturn), nod)


### PR DESCRIPTION
A blank key index is inserted during AST construction, to make
`for range X` equivalent of `for _ = range X` which works well.

Fix #258