### PR TITLE
interp/build: support custom build constraints.

### DIFF
--- a/interp/ast.go
+++ b/interp/ast.go
@@ -333,7 +333,7 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 		src = "package main; func main() {" + src + "}"
 	}
 
-	if !interp.buildOk(name, src) {
+	if !interp.buildOk(interp.context, name, src) {
 		return "", nil, nil // skip source not matching build constraints
 	}
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -59,11 +59,10 @@ type Exports map[string]map[string]reflect.Value
 
 // opt stores interpreter options
 type opt struct {
-	astDot  bool   // display AST graph (debug)
-	cfgDot  bool   // display CFG graph (debug)
-	noRun   bool   // compile, but do not run
-	goPath  string // custom GOPATH
-	context build.Context
+	astDot  bool          // display AST graph (debug)
+	cfgDot  bool          // display CFG graph (debug)
+	noRun   bool          // compile, but do not run
+	context build.Context // build context: GOPATH, build constraints
 }
 
 // Interpreter contains global resources and state
@@ -127,7 +126,7 @@ type Options struct {
 // New returns a new interpreter
 func New(options Options) *Interpreter {
 	i := Interpreter{
-		opt:      opt{goPath: options.GoPath, context: build.Default},
+		opt:      opt{context: build.Default},
 		fset:     token.NewFileSet(),
 		universe: initUniverse(),
 		scopes:   map[string]*scope{},
@@ -135,6 +134,7 @@ func New(options Options) *Interpreter {
 		frame:    &frame{data: []reflect.Value{}},
 	}
 
+	i.opt.context.GOPATH = options.GoPath
 	if len(options.BuildTags) > 0 {
 		i.opt.context.BuildTags = options.BuildTags
 	}

--- a/interp/src.go
+++ b/interp/src.go
@@ -40,7 +40,7 @@ func (interp *Interpreter) importSrcFile(rPath, path, alias string) error {
 	// Parse source files
 	for _, file := range files {
 		name := file.Name()
-		if skipFile(name) {
+		if skipFile(interp.context, name) {
 			continue
 		}
 

--- a/interp/src.go
+++ b/interp/src.go
@@ -22,7 +22,7 @@ func (interp *Interpreter) importSrcFile(rPath, path, alias string) error {
 			rPath = "."
 		}
 		dir = filepath.Join(filepath.Dir(interp.Name), rPath, path)
-	} else if dir, rPath, err = pkgDir(interp.goPath, rPath, path); err != nil {
+	} else if dir, rPath, err = pkgDir(interp.context.GOPATH, rPath, path); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use of build.Context to handle custom build tags. Let user define a list of build tags in interpreter options.

Fixes #307