### PR TITLE
Updated alias for installation from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ go get -u github.com/containous/yaegi/cmd/yaegi
 ```
 
 Note that you can use [rlwrap](https://github.com/hanslub42/rlwrap) (install with your favorite package manager),
-and alias the `yaegi` command in `alias yaegi='rlwrap yaegi'` in your `~/.bashrc`, to have history and command line edition.
+and alias the `yaegi` command in `alias yaegi='rlwrap /Users/your-username/your-workspace-dir/bin/yaegi'` in your `~/.bash_profile`, to have history and command line edition.
 
 ## Usage
 


### PR DESCRIPTION
go get was not enough for me to get in a position to simpli write `yaegi` and work.
I'm on macos mojave with golang 1.12

Update the doc with how i fixed it. If it works with the previous directions on linux, i'd propose a mix of the two in the readme