### PR TITLE
Fuzzing integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: go
 dist: xenial
 
 env:
-  - GO111MODULE=on
+  global:
+    - GO111MODULE=on
+    # FUZZIT_API_KEY
+    - secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
 
 notifications:
   email:
@@ -37,6 +40,19 @@ script:
   - make check
   - go build -v ./...
   - make tests
+
+jobs:
+  include:
+    - stage: Fuzz regression
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh fuzzing
 
 deploy:
   - provider: script

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![release](https://img.shields.io/github/tag-date/containous/yaegi.svg?label=alpha)](https://github.com/containous/yaegi/releases)
 [![Build Status](https://travis-ci.com/containous/yaegi.svg?branch=master)](https://travis-ci.com/containous/yaegi)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=containous)](https://app.fuzzit.dev/orgs/containous/dashboard)
 [![GoDoc](https://godoc.org/github.com/containous/yaegi?status.svg)](https://godoc.org/github.com/containous/yaegi)
 [![Discourse status](https://img.shields.io/discourse/https/community.containo.us/status?label=Community&style=social)](https://community.containo.us/c/yaegi)
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -xe
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+
+NAME=gojay
+TYPE=$1
+
+# Setup
+export GO111MODULE="off"
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+go get -d -v -u ./...
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Fuzz
+go-fuzz-build -libfuzzer -o fuzzer.a ./interp
+clang -fsanitize=fuzzer fuzzer.a -o fuzzer
+./fuzzit create job $LOCAL --type $TYPE yaegi fuzzer

--- a/interp/interp_fuzz.go
+++ b/interp/interp_fuzz.go
@@ -1,0 +1,12 @@
+// +build gofuzz
+
+package interp
+
+func Fuzz(input []byte) int {
+	interpreter := New(Options{})
+	_, err := interpreter.Eval(string(input))
+	if err != nil {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Hi guys. Proposing to add integration with a fuzzing service. Fuzzit gives free service to open source projects.

This patch fuzzes the `Eval()` method.

The build will fail due to an absent API key. I've run [successful tests](https://travis-ci.org/bookmoons/yaegi/builds/575198721) under my own Travis account. If you're interested the setup is like this:
* In [Fuzzit](https://fuzzit.dev/) create a target `yaegi`.
* In Fuzzit settings grab an API key. In repo settings in [Travis](https://travis-ci.org/) paste it to an envvar `FUZZIT_API_KEY`.

A local fuzzing run caught a bunch of crashing bugs. Going to post the data and some examples.