### PR TITLE
fix: iterate on global type analyis when necessary

### DIFF
--- a/_test/method21.go
+++ b/_test/method21.go
@@ -13,3 +13,6 @@ func (*Hello) Hi() string {
 func main() {
 	fmt.Println(&Hello{})
 }
+
+// Output:
+// &{}

--- a/_test/method22.go
+++ b/_test/method22.go
@@ -1,0 +1,19 @@
+package main
+
+func Bar() {
+	s := Obj.Foo()
+	println(s)
+}
+
+var Obj = &T{}
+
+type T struct{}
+
+func (t *T) Foo() bool { return t != nil }
+
+func main() {
+	Bar()
+}
+
+// Output:
+// true

--- a/_test/method23.go
+++ b/_test/method23.go
@@ -1,0 +1,21 @@
+package main
+
+func Bar() {
+	s := Obj.Foo()
+	println(s)
+}
+
+var Obj = NewT()
+
+func NewT() *T { return &T{} }
+
+type T struct{}
+
+func (t *T) Foo() bool { return t != nil }
+
+func main() {
+	Bar()
+}
+
+// Output:
+// true

--- a/_test/struct12.go
+++ b/_test/struct12.go
@@ -13,3 +13,6 @@ type S2 struct {
 func main() {
 	fmt.Println(S2{})
 }
+
+// Output:
+// {<nil>}

--- a/_test/struct15.go
+++ b/_test/struct15.go
@@ -21,3 +21,6 @@ func (w GzipResponseWriterWithCloseNotify) CloseNotify() <-chan bool {
 func main() {
 	fmt.Println("hello")
 }
+
+// Output:
+// hello

--- a/_test/struct19.go
+++ b/_test/struct19.go
@@ -21,3 +21,6 @@ func main() {
 	c := CreateConfig()
 	fmt.Println(c)
 }
+
+// Output:
+// &{[]   false }

--- a/_test/type12.go
+++ b/_test/type12.go
@@ -25,3 +25,6 @@ func main() {
 	t := &T1{}
 	println(t.Get())
 }
+
+// Output:
+// no name

--- a/_test/type13.go
+++ b/_test/type13.go
@@ -1,0 +1,12 @@
+package main
+
+var a = &T{}
+
+type T struct{}
+
+func main() {
+	println(a != nil)
+}
+
+// Output:
+// true

--- a/_test/type14.go
+++ b/_test/type14.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var a = T{}
+
+type T struct{}
+
+func main() {
+	fmt.Println(a)
+}
+
+// Output:
+// {}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -245,8 +245,14 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 	}
 
 	// Global type analysis
-	if err = interp.gta(root, pkgName); err != nil {
+	revisit, err := interp.gta(root, pkgName)
+	if err != nil {
 		return res, err
+	}
+	for _, n := range revisit {
+		if _, err = interp.gta(n, pkgName); err != nil {
+			return res, err
+		}
 	}
 
 	// Annotate AST with CFG infos


### PR DESCRIPTION
For global assign expressions, it may be necessary to re-iterate
GTA, in particular when source type is defined later.
This change allows gta() to return the list of ast nodes to revisit
prior to enter in CFG.

A number of related tests are added, or fixed (missing output).

Fix #331