### PR TITLE
fix: improve handling of global declarations, possibly out of order

### DIFF
--- a/_test/a32.go
+++ b/_test/a32.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+type T struct{}
+
+var a = []T{{}}
+
+func main() {
+	fmt.Println(a)
+}
+
+// Output:
+// [{}]

--- a/_test/composite0.go
+++ b/_test/composite0.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var a = &[]*T{}
+
+type T struct{ name string }
+
+func main() {
+	fmt.Println(a)
+}
+
+// Output:
+// &[]

--- a/_test/composite1.go
+++ b/_test/composite1.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var a = &[]*T{{}}
+
+type T struct{ name string }
+
+func main() {
+	fmt.Println((*a)[0])
+}
+
+// Output:
+// &{}

--- a/_test/composite2.go
+++ b/_test/composite2.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var a = &[]*T{{"hello"}}
+
+type T struct{ name string }
+
+func main() {
+	fmt.Println((*a)[0])
+}
+
+// Output:
+// &{hello}

--- a/_test/method24.go
+++ b/_test/method24.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Pool struct {
+	p *sync.Pool
+}
+
+func (p Pool) Get() *Buffer { return &Buffer{} }
+
+func NewPool() Pool { return Pool{} }
+
+type Buffer struct {
+	bs   []byte
+	pool Pool
+}
+
+var (
+	_pool = NewPool()
+	Get   = _pool.Get
+)
+
+func main() {
+	fmt.Println(_pool)
+	fmt.Println(Get())
+}
+
+// Output:
+// {<nil>}
+// &{[] {<nil>}}

--- a/_test/select0.go
+++ b/_test/select0.go
@@ -9,6 +9,9 @@ func forever() {
 
 func main() {
 	go forever()
-	time.Sleep(1e9)
+	time.Sleep(1e4)
 	println("bye")
 }
+
+// Output:
+// bye

--- a/_test/struct24.go
+++ b/_test/struct24.go
@@ -1,0 +1,12 @@
+package main
+
+var a = &T{}
+
+type T struct{}
+
+func main() {
+	println(a != nil)
+}
+
+// Output:
+// true

--- a/_test/struct25.go
+++ b/_test/struct25.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var a = T{}
+
+type T struct{}
+
+func main() {
+	fmt.Println(a)
+}
+
+// Output:
+// {}

--- a/_test/time8.go
+++ b/_test/time8.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"time"
+)
+
+type durationValue time.Duration
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+func main() {
+	var d durationValue
+	println(d.String())
+}
+
+// Output:
+// 0s

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1656,7 +1656,8 @@ func gotoLabel(s *symbol) {
 
 func compositeGenerator(n *node) (gen bltnGenerator) {
 	switch n.typ.cat {
-	case aliasT:
+	case aliasT, ptrT:
+		n.typ.val.untyped = n.typ.untyped
 		n.typ = n.typ.val
 		gen = compositeGenerator(n)
 	case arrayT:
@@ -1664,12 +1665,9 @@ func compositeGenerator(n *node) (gen bltnGenerator) {
 	case mapT:
 		gen = mapLit
 	case structT:
-		switch {
-		case len(n.child) == 0:
-			gen = nop
-		case n.lastChild().kind == keyValueExpr:
+		if len(n.child) > 0 && n.lastChild().kind == keyValueExpr {
 			gen = compositeSparse
-		default:
+		} else {
 			gen = compositeLit
 		}
 	case valueT:

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -183,7 +183,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			}
 
 		case compositeLitExpr:
-			if n.child[0].isType(sc) {
+			if len(n.child) > 0 && n.child[0].isType(sc) {
 				// Get type from 1st child
 				if n.typ, err = nodeType(interp, sc, n.child[0]); err != nil {
 					return false
@@ -352,10 +352,6 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 				var sym *symbol
 				var level int
 				if n.kind == defineStmt || (n.kind == assignStmt && dest.ident == "_") {
-					if src.typ != nil && src.typ.cat == nilT {
-						err = src.cfgErrorf("use of untyped nil")
-						break
-					}
 					if atyp != nil {
 						dest.typ = atyp
 					} else {
@@ -1074,11 +1070,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 				}
 			} else if n.typ.cat == ptrT && (n.typ.val.cat == valueT || n.typ.val.cat == errorT) {
 				// Handle pointer on object defined in runtime
-				if field, ok := n.typ.val.rtype.FieldByName(n.child[1].ident); ok {
-					n.typ = &itype{cat: valueT, rtype: field.Type}
-					n.val = field.Index
-					n.gen = getPtrIndexSeq
-				} else if method, ok := n.typ.val.rtype.MethodByName(n.child[1].ident); ok {
+				if method, ok := n.typ.val.rtype.MethodByName(n.child[1].ident); ok {
 					n.val = method.Index
 					n.typ = &itype{cat: valueT, rtype: method.Type}
 					n.recv = &receiver{node: n.child[0]}
@@ -1088,6 +1080,11 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 					n.gen = getIndexBinMethod
 					n.typ = &itype{cat: valueT, rtype: method.Type}
 					n.recv = &receiver{node: n.child[0]}
+				} else if field, ok := n.typ.val.rtype.FieldByName(n.child[1].ident); ok {
+					n.typ = &itype{cat: valueT, rtype: field.Type}
+					n.val = field.Index
+					n.gen = getPtrIndexSeq
+
 				} else {
 					err = n.cfgErrorf("undefined selector: %s", n.child[1].ident)
 				}
@@ -1600,6 +1597,13 @@ func getExec(n *node) bltn {
 	return n.exec
 }
 
+func fileNode(n *node) *node {
+	if n == nil || n.kind == fileStmt {
+		return n
+	}
+	return fileNode(n.anc)
+}
+
 // setExec recursively sets the node exec builtin function by walking the CFG
 // from the entry point (first node to exec).
 func setExec(n *node) {
@@ -1660,9 +1664,12 @@ func compositeGenerator(n *node) (gen bltnGenerator) {
 	case mapT:
 		gen = mapLit
 	case structT:
-		if n.lastChild().kind == keyValueExpr {
+		switch {
+		case len(n.child) == 0:
+			gen = nop
+		case n.lastChild().kind == keyValueExpr:
 			gen = compositeSparse
-		} else {
+		default:
 			gen = compositeLit
 		}
 	case valueT:

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -112,7 +112,7 @@ func TestEvalNil(t *testing.T) {
 	i := interp.New(interp.Options{})
 	i.Use(stdlib.Symbols)
 	runTests(t, i, []testCase{
-		{desc: "assign nil", src: "a := nil", err: "1:28: use of untyped nil"},
+		{desc: "assign nil", src: "a := nil", err: "1:33: use of untyped nil"},
 		{desc: "return nil", pre: func() { eval(t, i, "func getNil() error {return nil}") }, src: "getNil()", res: "<nil>"},
 		{
 			desc: "return func which return error",

--- a/interp/run.go
+++ b/interp/run.go
@@ -1453,7 +1453,11 @@ func compositeLit(n *node) {
 		for i, v := range values {
 			a.Field(i).Set(v(f))
 		}
-		value(f).Set(a)
+		if d := value(f); d.Type().Kind() == reflect.Ptr {
+			d.Set(a.Addr())
+		} else {
+			d.Set(a)
+		}
 		return next
 	}
 }
@@ -1484,7 +1488,11 @@ func compositeSparse(n *node) {
 		for i, v := range values {
 			a.Field(i).Set(v(f))
 		}
-		value(f).Set(a)
+		if d := value(f); d.Type().Kind() == reflect.Ptr {
+			d.Set(a.Addr())
+		} else {
+			d.Set(a)
+		}
 		return next
 	}
 }

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -162,8 +162,8 @@ func (interp *Interpreter) initScopePkg(n *node) (*scope, string) {
 	sc := interp.universe
 	pkgName := mainID
 
-	if n.kind == fileStmt {
-		pkgName = n.child[0].ident
+	if p := fileNode(n); p != nil {
+		pkgName = p.child[0].ident
 	}
 
 	if _, ok := interp.scopes[pkgName]; !ok {


### PR DESCRIPTION
Handle global assign expressions involving struct fields or method.

Improve handling of out of order.

Improve detection of use of untyped nil.

Increase test coverage.

Fix #269
Fix #337

Not able yet to import "go.uber.org/zap", "github.com/spf13/cobra" or
other complex packages.