### PR TITLE
fix: assign a function value to a pre-declared variable

### DIFF
--- a/_test/assign9.go
+++ b/_test/assign9.go
@@ -1,0 +1,15 @@
+package main
+
+type foo func(b int)
+
+func boo(b int) { println("boo", b) }
+
+func main() {
+	var f foo
+
+	f = boo
+	f(4)
+}
+
+// Output:
+// boo 4

--- a/interp/run.go
+++ b/interp/run.go
@@ -1929,7 +1929,7 @@ func reset(n *node) {
 
 	switch l := len(n.child) - 1; l {
 	case 1:
-		typ := n.child[0].typ.TypeOf()
+		typ := n.child[0].typ.frameType()
 		i := n.child[0].findex
 		n.exec = func(f *frame) bltn {
 			f.data[i] = reflect.New(typ).Elem()
@@ -1938,7 +1938,7 @@ func reset(n *node) {
 	case 2:
 		c0, c1 := n.child[0], n.child[1]
 		i0, i1 := c0.findex, c1.findex
-		t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
+		t0, t1 := c0.typ.frameType(), c1.typ.frameType()
 		n.exec = func(f *frame) bltn {
 			f.data[i0] = reflect.New(t0).Elem()
 			f.data[i1] = reflect.New(t1).Elem()
@@ -1949,7 +1949,7 @@ func reset(n *node) {
 		index := make([]int, l)
 		for i, c := range n.child[:l] {
 			index[i] = c.findex
-			types[i] = c.typ.TypeOf()
+			types[i] = c.typ.frameType()
 		}
 		n.exec = func(f *frame) bltn {
 			for i, ind := range index {

--- a/interp/type.go
+++ b/interp/type.go
@@ -752,8 +752,11 @@ func (t *itype) TypeOf() reflect.Type {
 	return t.rtype
 }
 
-func (t *itype) frameType() reflect.Type {
-	var r reflect.Type
+func (t *itype) frameType() (r reflect.Type) {
+	var err error
+	if t, err = t.finalize(); err != nil {
+		panic(err)
+	}
 	switch t.cat {
 	case arrayT:
 		if t.size > 0 {


### PR DESCRIPTION
For functions used internally in the interpreter the frame type
is a node pointer, correctly set by frameType() rather than TypeOf().

Fix #338