### PR TITLE
fix: improve handling of out of order declarations

### DIFF
--- a/_test/fun6.go
+++ b/_test/fun6.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func NewPool() Pool { return Pool{} }
+
+type Pool struct {
+	p *sync.Pool
+}
+
+var _pool = NewPool()
+
+func main() {
+	fmt.Println(_pool)
+}
+
+// Output:
+// {<nil>}

--- a/_test/method25.go
+++ b/_test/method25.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func (p Pool) Get() *Buffer { return &Buffer{} }
+
+func NewPool() Pool { return Pool{} }
+
+type Buffer struct {
+	bs   []byte
+	pool Pool
+}
+
+type Pool struct {
+	p *sync.Pool
+}
+
+var (
+	_pool = NewPool()
+	Get   = _pool.Get
+)
+
+func main() {
+	fmt.Println(_pool)
+	fmt.Println(Get())
+}
+
+// Output:
+// {<nil>}
+// &{[] {<nil>}}

--- a/_test/method26.go
+++ b/_test/method26.go
@@ -1,0 +1,18 @@
+package main
+
+func NewT(name string) *T { return &T{name} }
+
+var C = NewT("test")
+
+func (t *T) f() { println(t == C) }
+
+type T struct {
+	Name string
+}
+
+func main() {
+	C.f()
+}
+
+// Output:
+// true

--- a/_test/struct26.go
+++ b/_test/struct26.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func newT2() *T2 { return &T2{} }
+
+type T2 struct {
+	T1
+}
+
+type T1 struct {
+	bs []byte
+}
+
+func main() {
+	fmt.Println(newT2())
+}
+
+// Output:
+// &{{[]}}

--- a/_test/struct27.go
+++ b/_test/struct27.go
@@ -1,0 +1,18 @@
+package main
+
+import "fmt"
+
+func (f *Foo) Boo() { fmt.Println(f.name, "Boo") }
+
+type Foo struct {
+	name string
+	fun  func(f *Foo)
+}
+
+func main() {
+	t := &Foo{name: "foo"}
+	t.Boo()
+}
+
+// Output:
+// foo Boo

--- a/_test/struct28.go
+++ b/_test/struct28.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type T1 struct {
+	T2
+}
+
+type T2 struct {
+	*T1
+}
+
+func main() {
+	t := T1{}
+	fmt.Println(t)
+}
+
+// Output:
+// {{<nil>}}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -491,6 +491,8 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			c0, c1 := n.child[0], n.child[1]
 			t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
 			if !c0.typ.untyped && !c1.typ.untyped && c0.typ.id() != c1.typ.id() {
+				log.Println(c0.typ.pkgPath)
+				log.Println(c1.typ.pkgPath)
 				err = n.cfgErrorf("mismatched types %s and %s", c0.typ.id(), c1.typ.id())
 				break
 			}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -355,6 +355,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 					if atyp != nil {
 						dest.typ = atyp
 					} else {
+						if src.typ, err = nodeType(interp, sc, src); err != nil {
+							return
+						}
 						dest.typ = src.typ
 					}
 					if dest.typ.sizedef {

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -491,8 +491,6 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			c0, c1 := n.child[0], n.child[1]
 			t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
 			if !c0.typ.untyped && !c1.typ.untyped && c0.typ.id() != c1.typ.id() {
-				log.Println(c0.typ.pkgPath)
-				log.Println(c1.typ.pkgPath)
 				err = n.cfgErrorf("mismatched types %s and %s", c0.typ.id(), c1.typ.id())
 				break
 			}

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -44,17 +44,16 @@ func (k sKind) String() string {
 // A symbol represents an interpreter object such as type, constant, var, func,
 // label, builtin or binary object. Symbols are defined within a scope.
 type symbol struct {
-	kind      sKind
-	typ       *itype        // Type of value
-	node      *node         // Node value if index is negative
-	from      []*node       // list of nodes jumping to node if kind is label, or nil
-	recv      *receiver     // receiver node value, if sym refers to a method
-	index     int           // index of value in frame or -1
-	rval      reflect.Value // default value (used for constants)
-	path      string        // package path if typ.cat is SrcPkgT or BinPkgT
-	builtin   bltnGenerator // Builtin function or nil
-	global    bool          // true if symbol is defined in global space
-	recursive bool          // true if symbol is a recursive type definition
+	kind    sKind
+	typ     *itype        // Type of value
+	node    *node         // Node value if index is negative
+	from    []*node       // list of nodes jumping to node if kind is label, or nil
+	recv    *receiver     // receiver node value, if sym refers to a method
+	index   int           // index of value in frame or -1
+	rval    reflect.Value // default value (used for constants)
+	path    string        // package path if typ.cat is SrcPkgT or BinPkgT
+	builtin bltnGenerator // Builtin function or nil
+	global  bool          // true if symbol is defined in global space
 	// TODO: implement constant checking
 	//constant bool             // true if symbol value is constant
 }

--- a/interp/type.go
+++ b/interp/type.go
@@ -517,15 +517,23 @@ func init() {
 func (t *itype) finalize() (*itype, error) {
 	var err cfgError
 	if t.incomplete {
+		sym, _, found := t.scope.lookup(t.name)
+		if found && !sym.typ.incomplete {
+			sym.typ.method = append(sym.typ.method, t.method...)
+			return sym.typ, nil
+		}
 		m := t.method
 		if t, err = nodeType(t.node.interp, t.scope, t.node); err != nil {
 			return nil, err
 		}
 		if t.incomplete {
-			return nil, t.node.cfgErrorf("incomplete type")
+			return nil, t.node.cfgErrorf("incomplete type %s", t.name)
 		}
 		t.method = m
 		t.node.typ = t
+		if sym != nil {
+			sym.typ = t
+		}
 	}
 	return t, err
 }

--- a/interp/type.go
+++ b/interp/type.go
@@ -416,14 +416,13 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 
 	case structType:
 		t.cat = structT
-		var incomplete bool
-		//var incomplete, found bool
-		//var sym *symbol
-		//if sname := structName(n); sname != "" {
-		//	if sym, _, found = sc.lookup(sname); found && sym.kind == typeSym {
-		//		sym.typ = t
-		//	}
-		//}
+		var incomplete, found bool
+		var sym *symbol
+		if sname := structName(n); sname != "" {
+			if sym, _, found = sc.lookup(sname); found && sym.kind == typeSym {
+				sym.typ = t
+			}
+		}
 		for _, c := range n.child[0].child {
 			switch {
 			case len(c.child) == 1:

--- a/interp/type.go
+++ b/interp/type.go
@@ -132,9 +132,10 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 
 	if n.anc.kind == typeSpec {
 		name := n.anc.child[0].ident
-		if sc.sym[name] != nil {
+		if sym := sc.sym[name]; sym != nil {
 			// recover previously declared methods
-			t.method = sc.sym[name].typ.method
+			t.method = sym.typ.method
+			t.pkgPath = sym.typ.pkgPath
 			t.name = name
 		}
 	}

--- a/interp/type.go
+++ b/interp/type.go
@@ -130,6 +130,15 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 
 	var t = &itype{node: n, scope: sc}
 
+	if n.anc.kind == typeSpec {
+		name := n.anc.child[0].ident
+		if sc.sym[name] != nil {
+			// recover previously declared methods
+			t.method = sc.sym[name].typ.method
+			t.name = name
+		}
+	}
+
 	switch n.kind {
 	case addressExpr, starExpr:
 		t.cat = ptrT
@@ -314,11 +323,6 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 	case identExpr:
 		if sym, _, found := sc.lookup(n.ident); found {
 			t = sym.typ
-			if sym.recursive && t.incomplete {
-				t.incomplete = false
-				t.rtype = reflect.TypeOf((*interface{})(nil)).Elem()
-				sym.typ = t
-			}
 			if t.incomplete && t.node != n {
 				m := t.method
 				if t, err = nodeType(interp, sc, t.node); err != nil {
@@ -412,13 +416,14 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 
 	case structType:
 		t.cat = structT
-		var incomplete, found bool
-		var sym *symbol
-		if sname := structName(n); sname != "" {
-			if sym, _, found = sc.lookup(sname); found && sym.kind == typeSym {
-				sym.recursive = true
-			}
-		}
+		var incomplete bool
+		//var incomplete, found bool
+		//var sym *symbol
+		//if sname := structName(n); sname != "" {
+		//	if sym, _, found = sc.lookup(sname); found && sym.kind == typeSym {
+		//		sym.typ = t
+		//	}
+		//}
 		for _, c := range n.child[0].child {
 			switch {
 			case len(c.child) == 1:
@@ -460,7 +465,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 	}
 
 	if t.cat == nilT && !t.incomplete {
-		err = n.cfgErrorf("use of untyped nil")
+		err = n.cfgErrorf("use of untyped nil %s", t.name)
 	}
 
 	return t, err
@@ -699,7 +704,7 @@ func exportName(s string) string {
 }
 
 // TypeOf returns the reflection type of dynamic interpreter type t.
-func (t *itype) TypeOf() reflect.Type {
+func (t *itype) Type(name string) reflect.Type {
 	if t.rtype != nil {
 		return t.rtype
 	}
@@ -710,26 +715,29 @@ func (t *itype) TypeOf() reflect.Type {
 			panic(err)
 		}
 	}
+	if name == "" {
+		name = t.name
+	}
 
 	switch t.cat {
 	case arrayT:
 		if t.size > 0 {
-			t.rtype = reflect.ArrayOf(t.size, t.val.TypeOf())
+			t.rtype = reflect.ArrayOf(t.size, t.val.Type(name))
 		} else {
-			t.rtype = reflect.SliceOf(t.val.TypeOf())
+			t.rtype = reflect.SliceOf(t.val.Type(name))
 		}
 	case chanT:
-		t.rtype = reflect.ChanOf(reflect.BothDir, t.val.TypeOf())
+		t.rtype = reflect.ChanOf(reflect.BothDir, t.val.Type(name))
 	case errorT:
 		t.rtype = reflect.TypeOf(new(error)).Elem()
 	case funcT:
 		in := make([]reflect.Type, len(t.arg))
 		out := make([]reflect.Type, len(t.ret))
 		for i, v := range t.arg {
-			in[i] = v.TypeOf()
+			in[i] = v.Type(name)
 		}
 		for i, v := range t.ret {
-			out[i] = v.TypeOf()
+			out[i] = v.Type(name)
 		}
 		t.rtype = reflect.FuncOf(in, out, false)
 	case interfaceT:
@@ -737,18 +745,14 @@ func (t *itype) TypeOf() reflect.Type {
 	case mapT:
 		t.rtype = reflect.MapOf(t.key.TypeOf(), t.val.TypeOf())
 	case ptrT:
-		// FIXME: the following should probably be done in nodeType() instead
-		if t.val.cat == nilT {
-			t.val.incomplete = true
-			if s, _, ok := t.scope.lookup(t.val.name); ok {
-				t.val = s.typ
-			}
+		if t.val != nil && name != "" && t.val.name == name {
+			t.val.rtype = reflect.TypeOf(new(interface{})).Elem()
 		}
-		t.rtype = reflect.PtrTo(t.val.TypeOf())
+		t.rtype = reflect.PtrTo(t.val.Type(name))
 	case structT:
 		var fields []reflect.StructField
 		for _, f := range t.field {
-			field := reflect.StructField{Name: exportName(f.name), Type: f.typ.TypeOf(), Tag: reflect.StructTag(f.tag)}
+			field := reflect.StructField{Name: exportName(f.name), Type: f.typ.Type(name), Tag: reflect.StructTag(f.tag)}
 			fields = append(fields, field)
 		}
 		t.rtype = reflect.StructOf(fields)
@@ -758,6 +762,10 @@ func (t *itype) TypeOf() reflect.Type {
 		}
 	}
 	return t.rtype
+}
+
+func (t *itype) TypeOf() reflect.Type {
+	return t.Type(t.name)
 }
 
 func (t *itype) frameType() (r reflect.Type) {
@@ -772,29 +780,11 @@ func (t *itype) frameType() (r reflect.Type) {
 		} else {
 			r = reflect.SliceOf(t.val.frameType())
 		}
-	//case ChanT:
-	//	r = reflect.ChanOf(reflect.BothDir, t.val.frameType())
-	//case ErrorT:
-	//	r = reflect.TypeOf(new(error)).Elem()
 	case funcT:
 		r = reflect.TypeOf((*node)(nil))
 	case interfaceT:
 		r = reflect.TypeOf((*valueInterface)(nil)).Elem()
-	//case MapT:
-	//	r = reflect.MapOf(t.key.frameType(), t.val.frameType())
-	//case PtrT:
-	//	r = reflect.PtrTo(t.val.frameType())
-	//case StructT:
-	//	var fields []reflect.StructField
-	//	for _, f := range t.field {
-	//		field := reflect.StructField{Name: exportName(f.name), Type: f.typ.frameType()}
-	//		fields = append(fields, field)
-	//	}
-	//	r = reflect.StructOf(fields)
 	default:
-		//	if z, _ := t.zero(); z.IsValid() {
-		//		r = z.Type()
-		//	}
 		r = t.TypeOf()
 	}
 	return r


### PR DESCRIPTION
Provide enough informations in created incomplete symbol/type to
make sure it can be completed by finalize() method.
Make sure that incomplete type declarations are revisited.

Fix #343