### PR TITLE
fix: avoid collision between package names and function args

### DIFF
--- a/_test/fun6.go
+++ b/_test/fun6.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	goflag "flag"
+	"fmt"
+)
+
+func Foo(goflag *goflag.Flag) {
+	fmt.Println(goflag)
+}
+
+func main() {
+	g := &goflag.Flag{}
+	Foo(g)
+}
+
+// Output:
+// &{  <nil> }

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -221,6 +221,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case funcDecl:
 			n.val = n
+			// Compute function type before entering local scope to avoid
+			// possible collisions with function argument names.
+			n.child[2].typ, err = nodeType(interp, sc, n.child[2])
 			// Add a frame indirection level as we enter in a func
 			sc = sc.pushFunc()
 			sc.def = n


### PR DESCRIPTION
The correction here consists simply to compute the function signature
type before entering the fuction local scope.

Fix #346