### PR TITLE
fix: correct computation of type when dereference a binary object

### DIFF
--- a/_test/ptr7.go
+++ b/_test/ptr7.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type ipNetValue net.IPNet
+
+func (ipnet *ipNetValue) Set(value string) error {
+	_, n, err := net.ParseCIDR(strings.TrimSpace(value))
+	if err != nil {
+		return err
+	}
+	*ipnet = ipNetValue(*n)
+	return nil
+}
+
+func main() {
+	v := ipNetValue{}
+	fmt.Println(v)
+}
+
+// Output:
+// {<nil> <nil>}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1202,7 +1202,11 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			default:
 				// dereference expression
 				wireChild(n)
-				n.typ = n.child[0].typ.val
+				if c0 := n.child[0]; c0.typ.cat == valueT {
+					n.typ = &itype{cat: valueT, rtype: c0.typ.rtype.Elem()}
+				} else {
+					n.typ = c0.typ.val
+				}
 				n.findex = sc.add(n.typ)
 			}
 


### PR DESCRIPTION
When derefencing a binary object, the type must be computed using
typ.rtype.Elem() rather than typ.val (for non-binary objects).

Fix #348