### PR TITLE
fix: init global var from builtin

### DIFF
--- a/_test/map18.go
+++ b/_test/map18.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var foo = make([]int, 1)
+
+func main() {
+	for _, v := range foo {
+		fmt.Println(v)
+	}
+}
+
+// Output:
+// 0

--- a/_test/var7.go
+++ b/_test/var7.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+)
+
+type T struct {
+	Name string
+}
+
+var m = make(map[string]*T)
+
+func main() {
+	fmt.Println(m)
+}
+
+// Output:
+// map[]

--- a/interp/run.go
+++ b/interp/run.go
@@ -1717,6 +1717,11 @@ func appendSlice(n *node) {
 }
 
 func _append(n *node) {
+	if c1, c2 := n.child[1], n.child[2]; len(n.child) == 3 && c2.typ.cat == arrayT && c2.typ.val.id() == n.typ.val.id() ||
+		isByteArray(c1.typ.TypeOf()) && isString(c2.typ.TypeOf()) {
+		appendSlice(n)
+		return
+	}
 	dest := genValue(n)
 	value := genValue(n.child[1])
 	next := getExec(n.tnext)


### PR DESCRIPTION
The builtin type computation is now impletemented in nodeType()
instead of cfg(), to be applied in global declarations involving
builtin calls.

Fix #357