### PR TITLE
fix: global variable init from selector expression

### DIFF
--- a/_test/var8.go
+++ b/_test/var8.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type Message struct {
+	Name string
+}
+
+var protoMessageType = reflect.TypeOf((*Message)(nil)).Elem()
+
+func main() {
+	fmt.Println(protoMessageType.Kind())
+}
+
+// Output:
+// struct

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -99,7 +99,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 					elementType := sc.getType(typeName)
 					if elementType == nil {
 						// Add type if necessary, so method can be registered
-						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, pkgPath: rpath, incomplete: true, node: rtn.child[0], scope: sc}}
+						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: rpath, incomplete: true, node: rtn.child[0], scope: sc}}
 						elementType = sc.sym[typeName].typ
 					}
 					rcvrtype = &itype{cat: ptrT, val: elementType, incomplete: elementType.incomplete, node: rtn, scope: sc}
@@ -108,7 +108,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 					rcvrtype = sc.getType(typeName)
 					if rcvrtype == nil {
 						// Add type if necessary, so method can be registered
-						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, pkgPath: rpath, incomplete: true, node: rtn, scope: sc}}
+						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: rpath, incomplete: true, node: rtn, scope: sc}}
 						rcvrtype = sc.sym[typeName].typ
 					}
 				}
@@ -141,7 +141,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 						sc.sym[n] = &symbol{kind: binSym, typ: &itype{cat: valueT, rtype: typ}, rval: v}
 					}
 				default: // import symbols in package namespace
-					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT}, path: ipath}
+					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath}}
 				}
 			} else if err = interp.importSrc(rpath, ipath, name); err == nil {
 				sc.types = interp.universe.types
@@ -154,7 +154,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 						}
 					}
 				default: // import symbols in package namespace
-					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT}, path: ipath}
+					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: ipath}}
 				}
 			}
 
@@ -165,11 +165,11 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 				return false
 			}
 			if n.child[1].kind == identExpr {
-				n.typ = &itype{cat: aliasT, val: typ, name: typeName, pkgPath: rpath}
+				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath}
 			} else {
 				n.typ = typ
 				n.typ.name = typeName
-				n.typ.pkgPath = rpath
+				n.typ.path = rpath
 			}
 			// Type may already be declared for a receiver in a method function
 			if sc.sym[typeName] == nil {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -278,7 +278,7 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 	if interp.universe.sym[pkgName] == nil {
 		// Make the package visible under a path identical to its name
 		interp.srcPkg[pkgName] = interp.scopes[pkgName].sym
-		interp.universe.sym[pkgName] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT}, path: pkgName}
+		interp.universe.sym[pkgName] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: pkgName}}
 	}
 
 	if interp.cfgDot {

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -51,7 +51,6 @@ type symbol struct {
 	recv    *receiver     // receiver node value, if sym refers to a method
 	index   int           // index of value in frame or -1
 	rval    reflect.Value // default value (used for constants)
-	path    string        // package path if typ.cat is SrcPkgT or BinPkgT
 	builtin bltnGenerator // Builtin function or nil
 	global  bool          // true if symbol is defined in global space
 	// TODO: implement constant checking


### PR DESCRIPTION
In nodeType(), in presence of a selector expression, the logic was broken
for complex expressions. We now first compute the type of the left part
of the selector, then perform a lookup operation on it.

We now store the package path in type rather than symbol, to allow the
above on srcPkgT and binPkgT.

Fix #359