### PR TITLE
fix: conversion of type to reflect.Type avoids recursive loop

### DIFF
--- a/_test/recurse0.go
+++ b/_test/recurse0.go
@@ -1,0 +1,39 @@
+package main
+
+import "fmt"
+
+type T struct {
+	a []T
+	b []*T
+	c map[string]T
+	d map[string]*T
+	e chan T
+	f chan *T
+	h *T
+	i func(T) T
+	j func(*T) *T
+	U
+}
+
+type U struct {
+	k []T
+	l []*T
+	m map[string]T
+	n map[string]*T
+	o chan T
+	p chan *T
+	q *T
+	r func(T) T
+	s func(*T) *T
+}
+
+func main() {
+	t := T{}
+	u := U{}
+	fmt.Println(t)
+	fmt.Println(u)
+}
+
+// Output:
+// {[] [] map[] map[] <nil> <nil> <nil> <nil> <nil> {[] [] map[] map[] <nil> <nil> <nil> <nil> <nil>}}
+// {[] [] map[] map[] <nil> <nil> <nil> <nil> <nil>}


### PR DESCRIPTION
The conversion of interpreter type to reflect.Type now encodes a
recursive struct by an interface{} to avoid infinite loop.

A previous change fixed the problem for pointers to struct only,
now the refType() function addresses the problem globally:
arrays, maps, functions, channels, sub-structures, direct or
indirect cycles.

Note: further fixes may be necessary to properly get or set field
data of recursive structures. This will be addressed in a separate
change.

Fix #361