### PR TITLE
fix: support array operations on array pointers

### DIFF
--- a/_test/copy1.go
+++ b/_test/copy1.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := []int{10, 20, 30}
+	b := &[4]int{}
+	c := b[:]
+	copy(c, a)
+	fmt.Println(c)
+}
+
+// Output:
+// [10 20 30 0]

--- a/_test/ptr_array0.go
+++ b/_test/ptr_array0.go
@@ -1,0 +1,13 @@
+package main
+
+type T [2]int
+
+func F0(t *T) int { return t[0] }
+
+func main() {
+	t := &T{1, 2}
+	println(F0(t))
+}
+
+// Output:
+// 1

--- a/_test/ptr_array1.go
+++ b/_test/ptr_array1.go
@@ -1,0 +1,19 @@
+package main
+
+type T [3]int
+
+func F0(t *T) {
+	for i, v := range t {
+		println(i, v)
+	}
+}
+
+func main() {
+	t := &T{1, 2, 3}
+	F0(t)
+}
+
+// Output:
+// 0 1
+// 1 2
+// 2 3

--- a/_test/ptr_array2.go
+++ b/_test/ptr_array2.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+type T [2]int
+
+func F1(t *T) { t[0] = 1 }
+
+func main() {
+	t := &T{}
+	F1(t)
+	fmt.Println(t)
+}
+
+// Output:
+// &[1 0]

--- a/_test/ptr_array3.go
+++ b/_test/ptr_array3.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := &[...]int{1, 2, 3}
+	fmt.Println(a[:])
+}
+
+// Output:
+// [1 2 3]

--- a/interp/run.go
+++ b/interp/run.go
@@ -887,7 +887,7 @@ func getIndexBinPtrMethod(n *node) {
 // getIndexArray returns array value from index
 func getIndexArray(n *node) {
 	tnext := getExec(n.tnext)
-	value0 := genValue(n.child[0]) // array
+	value0 := genValueArray(n.child[0]) // array
 
 	if n.child[1].rval.IsValid() { // constant array index
 		ai := int(vInt(n.child[1].rval))
@@ -1505,8 +1505,8 @@ func _range(n *node) {
 	tnext := getExec(n.tnext)
 
 	if len(n.child) == 4 {
-		index1 := n.child[1].findex   // array value location in frame
-		value := genValue(n.child[2]) // array
+		index1 := n.child[1].findex        // array value location in frame
+		value := genValueArray(n.child[2]) // array
 		n.exec = func(f *frame) bltn {
 			a := value(f)
 			v0 := f.data[index0]
@@ -1519,7 +1519,7 @@ func _range(n *node) {
 			return tnext
 		}
 	} else {
-		value := genValue(n.child[1]) // array
+		value := genValueArray(n.child[1]) // array
 		n.exec = func(f *frame) bltn {
 			a := value(f)
 			v0 := f.data[index0]
@@ -1780,7 +1780,7 @@ func _cap(n *node) {
 
 func _copy(n *node) {
 	dest := genValue(n)
-	value0 := genValue(n.child[1])
+	value0 := genValueArray(n.child[1])
 	value1 := genValue(n.child[2])
 	next := getExec(n.tnext)
 
@@ -2109,8 +2109,8 @@ func _select(n *node) {
 func slice(n *node) {
 	i := n.findex
 	next := getExec(n.tnext)
-	value0 := genValue(n.child[0]) // array
-	value1 := genValue(n.child[1]) // low (if 2 or 3 args) or high (if 1 arg)
+	value0 := genValueArray(n.child[0]) // array
+	value1 := genValue(n.child[1])      // low (if 2 or 3 args) or high (if 1 arg)
 
 	switch len(n.child) {
 	case 2:
@@ -2143,7 +2143,7 @@ func slice(n *node) {
 func slice0(n *node) {
 	i := n.findex
 	next := getExec(n.tnext)
-	value0 := genValue(n.child[0])
+	value0 := genValueArray(n.child[0])
 
 	switch len(n.child) {
 	case 1:

--- a/interp/value.go
+++ b/interp/value.go
@@ -107,6 +107,17 @@ func genValue(n *node) func(*frame) reflect.Value {
 	}
 }
 
+func genValueArray(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+	// dereference array pointer, to support array operations on array pointer
+	if n.typ.TypeOf().Kind() == reflect.Ptr {
+		return func(f *frame) reflect.Value {
+			return value(f).Elem()
+		}
+	}
+	return value
+}
+
 func genValueInterfacePtr(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 	it := reflect.TypeOf((*interface{})(nil)).Elem()


### PR DESCRIPTION
Add array pointer support for index expressions (get and set), slice
expressions and copy() builtin. Provide related test cases.

Fix #368