### PR TITLE
fix: shift operator inherits its type from first arg only

### DIFF
--- a/_test/shift1.go
+++ b/_test/shift1.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+const a1 = 0x7f8 >> 3
+
+func main() {
+	fmt.Printf("%T %v\n", a1, a1)
+}
+
+// Output:
+// int 255

--- a/_test/shift2.go
+++ b/_test/shift2.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	var u uint64
+	var v uint32
+	println(u << v)
+}
+
+// Output:
+// 0

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -498,6 +498,8 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			nilSym := interp.universe.sym["nil"]
 			c0, c1 := n.child[0], n.child[1]
 			t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
+			// Shift operator type is inherited from first parameter only
+			// All other binary operators require both parameter types to be the same
 			if !isShiftNode(n) && !c0.typ.untyped && !c1.typ.untyped && c0.typ.id() != c1.typ.id() {
 				err = n.cfgErrorf("mismatched types %s and %s", c0.typ.id(), c1.typ.id())
 				break

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -498,7 +498,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			nilSym := interp.universe.sym["nil"]
 			c0, c1 := n.child[0], n.child[1]
 			t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
-			if !c0.typ.untyped && !c1.typ.untyped && c0.typ.id() != c1.typ.id() {
+			if !isShiftNode(n) && !c0.typ.untyped && !c1.typ.untyped && c0.typ.id() != c1.typ.id() {
 				err = n.cfgErrorf("mismatched types %s and %s", c0.typ.id(), c1.typ.id())
 				break
 			}

--- a/interp/type.go
+++ b/interp/type.go
@@ -224,6 +224,10 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				t.name = "int"
 			}
 			t.untyped = true
+		case uint:
+			t.cat = uintT
+			t.name = "uint"
+			t.untyped = true
 		case rune:
 			t.cat = runeT
 			t.name = "rune"
@@ -246,7 +250,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if t, err = nodeType(interp, sc, n.child[0]); err != nil {
 				return nil, err
 			}
-			if t.untyped {
+			if t.untyped && !isShiftNode(n) {
 				var t1 *itype
 				t1, err = nodeType(interp, sc, n.child[1])
 				if !(t1.untyped && isInt(t1.TypeOf()) && isFloat(t.TypeOf())) {
@@ -890,9 +894,16 @@ func defRecvType(n *node) *itype {
 	return nil
 }
 
-func isShiftOperand(n *node) bool {
-	switch n.anc.action {
+func isShiftNode(n *node) bool {
+	switch n.action {
 	case aShl, aShr, aShlAssign, aShrAssign:
+		return true
+	}
+	return false
+}
+
+func isShiftOperand(n *node) bool {
+	if isShiftNode(n.anc) {
 		return n.anc.lastChild() == n
 	}
 	return false

--- a/interp/type.go
+++ b/interp/type.go
@@ -250,6 +250,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if t, err = nodeType(interp, sc, n.child[0]); err != nil {
 				return nil, err
 			}
+			// Shift operator type is inherited from first parameter only
+			// For other operators, infer type in from 2nd parameter in case of untyped first
 			if t.untyped && !isShiftNode(n) {
 				var t1 *itype
 				t1, err = nodeType(interp, sc, n.child[1])


### PR DESCRIPTION
Make an exception for shift operators when computing the type and
 checking operands type consistency.
    
 Fix #308
