### PR TITLE
fix: handle forward declaration of alias type

### DIFF
--- a/_test/alias1.go
+++ b/_test/alias1.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+type MyT T
+
+type T struct {
+	Name string
+}
+
+func main() {
+	fmt.Println(MyT{})
+}
+
+// Output:
+// {}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -165,7 +165,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 				return false
 			}
 			if n.child[1].kind == identExpr {
-				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath}
+				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, incomplete: typ.incomplete}
 			} else {
 				n.typ = typ
 				n.typ.name = typeName


### PR DESCRIPTION
The incomplete status of the aliased type needs to be forwarded to the destination type.

Fix #378