### PR TITLE
interp: don't panic for undefined types

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -203,7 +203,10 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 				} else if n.anc.typ != nil {
 					n.typ = n.anc.typ.val
 				}
-				// FIXME n.typ can be nil.
+				if n.typ == nil {
+					err = n.cfgErrorf("undefined type")
+					return false
+				}
 				n.typ.untyped = true
 			}
 			// Propagate type to children, to handle implicit types


### PR DESCRIPTION
This prevents the runtime panic that otherwise occurs when a symbol that is referenced in a source is not present in the symbol map.

Please take a look.