### PR TITLE
fix: correct automatic type conversion for untyped constants

### DIFF
--- a/_test/shift3.go
+++ b/_test/shift3.go
@@ -1,0 +1,10 @@
+package main
+
+const a = 1.0
+
+const b = a + 3
+
+func main() { println(b << (1)) }
+
+// Output:
+// 8

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -44,11 +44,13 @@ func TestEvalArithmetic(t *testing.T) {
 		{desc: "rem_FI", src: "8.0 % 4", err: "1:28: illegal operand types for '%' operator"},
 		{desc: "shl_II", src: "1 << 8", res: "256"},
 		{desc: "shl_IN", src: "1 << -1", err: "1:28: illegal operand types for '<<' operator"},
-		{desc: "shl_IF", src: "1 << 1.0", err: "1:28: illegal operand types for '<<' operator"},
-		{desc: "shl_IF", src: "1.0 << 1", err: "1:28: illegal operand types for '<<' operator"},
+		{desc: "shl_IF", src: "1 << 1.0", res: "2"},
+		{desc: "shl_IF1", src: "1 << 1.1", err: "1:28: illegal operand types for '<<' operator"},
+		{desc: "shl_IF", src: "1.0 << 1", res: "2"},
 		{desc: "shr_II", src: "1 >> 8", res: "0"},
 		{desc: "shr_IN", src: "1 >> -1", err: "1:28: illegal operand types for '>>' operator"},
-		{desc: "shr_IF", src: "1 >> 1.0", err: "1:28: illegal operand types for '>>' operator"},
+		{desc: "shr_IF", src: "1 >> 1.0", res: "0"},
+		{desc: "shr_IF1", src: "1 >> 1.1", err: "1:28: illegal operand types for '>>' operator"},
 	})
 }
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -903,13 +903,6 @@ func isShiftNode(n *node) bool {
 	return false
 }
 
-func isShiftOperand(n *node) bool {
-	if isShiftNode(n.anc) {
-		return n.anc.lastChild() == n
-	}
-	return false
-}
-
 func isInterface(t *itype) bool { return t.cat == interfaceT || t.TypeOf().Kind() == reflect.Interface }
 
 func isStruct(t *itype) bool { return t.TypeOf().Kind() == reflect.Struct }

--- a/interp/type.go
+++ b/interp/type.go
@@ -215,14 +215,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			t.name = "float64"
 			t.untyped = true
 		case int:
-			if isShiftOperand(n) && v >= 0 {
-				t.cat = uintT
-				t.name = "uint"
-				n.rval = reflect.ValueOf(uint(v))
-			} else {
-				t.cat = intT
-				t.name = "int"
-			}
+			t.cat = intT
+			t.name = "int"
 			t.untyped = true
 		case uint:
 			t.cat = uintT


### PR DESCRIPTION
For the following operators: <<, >>, <<=, >>=, untyped constant
values are accepted if they are convertible to int and unsigned.

For example, `1 << 1.0` and `1.0 << 1` are valid but `1 << 1.1`
is not.

This change ensures the required properties are checked for untyped
constants and that result is properly converted and propagated.
Unit tests are updated to match the behaviour of the official go compiler.

Note: in the official go compiler, there may be an inconsistency in
the way untyped constants are processed, as the above behaviour
applies only for shift operations, not other bits operations. For
example, `1.0 & 1` is forbidden.

Fix #278