### PR TITLE
fix: compute type of slice expression globally

### DIFF
--- a/_test/var9.go
+++ b/_test/var9.go
@@ -1,0 +1,11 @@
+package main
+
+var a = "sdofjsdfj"
+var z = a[0:2]
+
+func main() {
+	println(z)
+}
+
+// Output:
+// sd

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1309,18 +1309,8 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case sliceExpr:
 			wireChild(n)
-			ctyp := n.child[0].typ
-			if ctyp.cat == ptrT {
-				ctyp = ctyp.val
-			}
-			if ctyp.size != 0 {
-				// Create a slice type from an array type
-				n.typ = &itype{}
-				*n.typ = *ctyp
-				n.typ.size = 0
-				n.typ.rtype = nil
-			} else {
-				n.typ = ctyp
+			if n.typ, err = nodeType(interp, sc, n); err != nil {
+				return
 			}
 			n.findex = sc.add(n.typ)
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -486,6 +486,18 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			}
 		}
 
+	case sliceExpr:
+		t, err = nodeType(interp, sc, n.child[0])
+		if t.cat == ptrT {
+			t = t.val
+		}
+		if err == nil && t.size != 0 {
+			t1 := *t
+			t1.size = 0
+			t1.rtype = nil
+			t = &t1
+		}
+
 	case structType:
 		t.cat = structT
 		var incomplete bool


### PR DESCRIPTION
The computation of slice expression is moved in nodeType to be
applied globally.

Fixes #316