### PR TITLE
fix: generate closures for literal functions in CFG

### DIFF
--- a/_test/closure8.go
+++ b/_test/closure8.go
@@ -1,0 +1,10 @@
+package main
+
+var f = func(a int) int { return 2 + a }
+
+func main() {
+	println(f(3))
+}
+
+// Output:
+// 5

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -871,7 +871,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 		case funcLit:
 			n.types = sc.types
 			sc = sc.pop()
-			genRun(n)
+			err = genRun(n)
 
 		case goStmt:
 			wireChild(n)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -871,6 +871,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 		case funcLit:
 			n.types = sc.types
 			sc = sc.pop()
+			genRun(n)
 
 		case goStmt:
 			wireChild(n)


### PR DESCRIPTION
Fixes #342