### PR TITLE
feature: add Stop() and EvalTimeout()

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -324,6 +324,8 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 // Stop stops the execution of the interpreter
 func (interp *Interpreter) Stop() { interp.runid++ }
 
+// EvalTimeout is the same as Eval, except it will return after a timeout it the
+// execution is not complete.
 func (interp *Interpreter) EvalTimeout(src string, d time.Duration) (v reflect.Value, err error) {
 	done := make(chan struct{})
 

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -461,6 +461,9 @@ func TestEvalStop(t *testing.T) {
 				return
 			}
 			_, err = i.EvalTimeout(src, 100*time.Millisecond)
+			if err == nil {
+				t.Errorf("should have failed")
+			}
 		}()
 		select {
 		case <-time.After(time.Second):

--- a/interp/run.go
+++ b/interp/run.go
@@ -84,7 +84,7 @@ func (interp *Interpreter) run(n *node, cf *frame) {
 	if cf == nil {
 		f = interp.frame
 	} else {
-		f = &frame{anc: cf, data: make([]reflect.Value, len(n.types))}
+		f = &frame{anc: cf, data: make([]reflect.Value, len(n.types)), runid: interp.runid}
 	}
 
 	for i, t := range n.types {
@@ -108,7 +108,7 @@ func runCfg(n *node, f *frame) {
 		}
 	}()
 
-	for exec := n.exec; exec != nil; {
+	for exec := n.exec; exec != nil && n.interp.runid == f.runid; {
 		exec = exec(f)
 	}
 }
@@ -438,7 +438,7 @@ func genFunctionWrapper(n *node) func(*frame) reflect.Value {
 		}
 		return reflect.MakeFunc(n.typ.TypeOf(), func(in []reflect.Value) []reflect.Value {
 			// Allocate and init local frame. All values to be settable and addressable.
-			fr := frame{anc: f, data: make([]reflect.Value, len(def.types))}
+			fr := frame{anc: f, data: make([]reflect.Value, len(def.types)), runid: f.runid}
 			d := fr.data
 			for i, t := range def.types {
 				d[i] = reflect.New(t).Elem()
@@ -652,7 +652,7 @@ func call(n *node) {
 		if def.frame != nil {
 			anc = def.frame
 		}
-		nf := frame{anc: anc, data: make([]reflect.Value, len(def.types))}
+		nf := frame{anc: anc, data: make([]reflect.Value, len(def.types)), runid: anc.runid}
 		var vararg reflect.Value
 
 		// Init return values


### PR DESCRIPTION
This is an alternate solution to `context.Context`, to implement
eval with timeout and cancellation, as per #386

This solution uses a `runid` counter added both to the execution
frames and the global `Interpreter` struct. When Eval starts, the
current `runid` from `Interpreter` is propagated to the frames
(a new frame is created at each function call, including closures
and goroutines; a frame inherits the `runid` from its ancestor).
in frames, the runid is written once at frame init, and never modified.
The interpreter runid can be modified to trigger the stop condition
(see Stop()).

Eval stop is triggered when the current frame runid is different
from the interpreter runid. This stop condition is evaluated in the
execution loop of `runCfg` at each instruction step. From my measures,
this integer equality test is 20 times faster than a select statement
on closed channel.

An interpreter session consists of multiple evals. Eval can spawn
a set of background goroutines. With this algorithm, all active
goroutines will be stopped, no matter which previous eval started
them. After a stop, a new Eval can happen.

To be more complete, a mechanism to unblock channels read/write, select
and locks must be added as well, this is planned in a further change.
This can be similar to a closed channel broadcast (as in context.Context)
except that the stop channel will be probably defined once in Interpreter
struct, and be used only for blocking calls, not execution loop. PR #387
proposed at some point an implementation of such interruptible blocking
calls.

The unit tests have been copied from PR #387.

the REPL has been modified to allow Eval interrupt by CTRL-C using
the above mechanism.

This is experimental at this point, and for discussion and comparison
with #387.