### PR TITLE
fix: assign a literal composite to an interface object

### DIFF
--- a/_test/interface12.go
+++ b/_test/interface12.go
@@ -1,0 +1,18 @@
+package main
+
+type I1 interface {
+	Truc()
+}
+
+type T1 struct{}
+
+func (T1) Truc() { println("in T1 truc") }
+
+var x I1 = T1{}
+
+func main() {
+	x.Truc()
+}
+
+// Output:
+// in T1 truc


### PR DESCRIPTION
Apply internal conversion to valueInterface when assigning
a litteral composite to an interface object.

Fixes #430