### PR TITLE
fix: correct handling of dynamic type for interface values

### DIFF
--- a/_test/interface12.go
+++ b/_test/interface12.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+)
+
+type X struct{}
+
+func (X) Foo() int {
+	return 1
+}
+func (X) Bar() int {
+	return 2
+}
+
+type Foo interface {
+	Foo() int
+}
+type Bar interface {
+	Bar() int
+}
+
+func main() {
+	var x X
+	var i Foo = x
+	j := i.(Bar)
+
+	fmt.Println(j.Bar())
+}
+
+// Output:
+// 2

--- a/interp/run.go
+++ b/interp/run.go
@@ -120,26 +120,26 @@ func runCfg(n *node, f *frame) {
 }
 
 func typeAssert(n *node) {
-	value := genValue(n.child[0])
-	i := n.findex
+	value := genValue(n.child[0]) // input value
+	dest := genValue(n)           // returned result
 	next := getExec(n.tnext)
 
 	switch {
 	case n.child[0].typ.cat == valueT:
 		n.exec = func(f *frame) bltn {
-			f.data[i].Set(value(f).Elem())
+			dest(f).Set(value(f).Elem())
 			return next
 		}
 	case n.child[1].typ.cat == interfaceT:
 		n.exec = func(f *frame) bltn {
 			v := value(f).Interface().(valueInterface)
-			f.data[i] = reflect.ValueOf(valueInterface{v.node, v.value})
+			dest(f).Set(reflect.ValueOf(valueInterface{v.node, v.value}))
 			return next
 		}
 	default:
 		n.exec = func(f *frame) bltn {
 			v := value(f).Interface().(valueInterface)
-			f.data[i].Set(v.value)
+			dest(f).Set(v.value)
 			return next
 		}
 	}

--- a/interp/value.go
+++ b/interp/value.go
@@ -159,7 +159,18 @@ func genValueInterface(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 
 	return func(f *frame) reflect.Value {
-		return reflect.ValueOf(valueInterface{n, value(f)})
+		v := value(f)
+		nod := n
+		for {
+			// traverse interface indirections to find out concrete type
+			vi, ok := v.Interface().(valueInterface)
+			if !ok {
+				break
+			}
+			v = vi.value
+			nod = vi.node
+		}
+		return reflect.ValueOf(valueInterface{nod, v})
 	}
 }
 


### PR DESCRIPTION
Dynamic type was lost when an interface was set from another
interface. Fix genValueInterface() to always find out concrete
type value, by walking interface indirections.

Fixes #436