### PR TITLE
fix: detect non boolean condition for IF and FOR statements

### DIFF
--- a/_test/for7.go
+++ b/_test/for7.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	for i := 0; i; {
+	}
+}
+
+// Error:
+// 4:14: non-bool used as for condition

--- a/_test/if2.go
+++ b/_test/if2.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	var i int
+	if i % 1000000 {
+		fmt.Println("oops")
+	}
+}
+
+// Error:
+// 7:5: non-bool used as if condition

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -820,6 +820,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case forStmt1: // for cond {}
 			cond, body := n.child[0], n.child[1]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as for condition")
+			}
 			n.start = cond.start
 			cond.tnext = body.start
 			cond.fnext = n
@@ -829,6 +832,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case forStmt2: // for init; cond; {}
 			init, cond, body := n.child[0], n.child[1], n.child[2]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as for condition")
+			}
 			n.start = init.start
 			init.tnext = cond.start
 			cond.tnext = body.start
@@ -839,6 +845,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case forStmt3: // for ; cond; post {}
 			cond, post, body := n.child[0], n.child[1], n.child[2]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as for condition")
+			}
 			n.start = cond.start
 			cond.tnext = body.start
 			cond.fnext = n
@@ -858,6 +867,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case forStmt4: // for init; cond; post {}
 			init, cond, post, body := n.child[0], n.child[1], n.child[2], n.child[3]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as for condition")
+			}
 			n.start = init.start
 			init.tnext = cond.start
 			cond.tnext = body.start
@@ -941,6 +953,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case ifStmt0: // if cond {}
 			cond, tbody := n.child[0], n.child[1]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as if condition")
+			}
 			n.start = cond.start
 			cond.tnext = tbody.start
 			cond.fnext = n
@@ -949,6 +964,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case ifStmt1: // if cond {} else {}
 			cond, tbody, fbody := n.child[0], n.child[1], n.child[2]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as if condition")
+			}
 			n.start = cond.start
 			cond.tnext = tbody.start
 			cond.fnext = fbody.start
@@ -958,6 +976,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case ifStmt2: // if init; cond {}
 			init, cond, tbody := n.child[0], n.child[1], n.child[2]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as if condition")
+			}
 			n.start = init.start
 			tbody.tnext = n
 			init.tnext = cond.start
@@ -967,6 +988,9 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 
 		case ifStmt3: // if init; cond {} else {}
 			init, cond, tbody, fbody := n.child[0], n.child[1], n.child[2], n.child[3]
+			if !isBool(cond.typ) {
+				err = cond.cfgErrorf("non-bool used as if condition")
+			}
 			n.start = init.start
 			init.tnext = cond.start
 			cond.tnext = tbody.start

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -35,6 +35,8 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "bad0.go" || // expect error
 			file.Name() == "export1.go" || // non-main package
 			file.Name() == "export0.go" || // non-main package
+			file.Name() == "for7.go" || // expect error
+			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "io0.go" || // use random number
 			file.Name() == "op1.go" || // expect error
@@ -135,6 +137,16 @@ func TestInterpErrorConsistency(t *testing.T) {
 			fileName:       "bad0.go",
 			expectedInterp: "1:1: expected 'package', found println",
 			expectedExec:   "1:1: expected 'package', found println",
+		},
+		{
+			fileName:       "if2.go",
+			expectedInterp: "7:5: non-bool used as if condition",
+			expectedExec:   "7:2: non-bool i % 1000000 (type int) used as if condition",
+		},
+		{
+			fileName:       "for7.go",
+			expectedInterp: "4:14: non-bool used as for condition",
+			expectedExec:   "4:2: non-bool i (type int) used as for condition",
 		},
 		{
 			fileName:       "op1.go",

--- a/interp/type.go
+++ b/interp/type.go
@@ -935,6 +935,17 @@ func isInterface(t *itype) bool {
 
 func isStruct(t *itype) bool { return t.TypeOf().Kind() == reflect.Struct }
 
+func isBool(t *itype) bool {
+	switch t.TypeOf().Kind() {
+	case reflect.Bool:
+		return true
+	case reflect.Chan:
+		return t.TypeOf().Elem().Kind() == reflect.Bool
+	default:
+		return false
+	}
+}
+
 func isInt(t reflect.Type) bool {
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:

--- a/interp/type.go
+++ b/interp/type.go
@@ -935,16 +935,7 @@ func isInterface(t *itype) bool {
 
 func isStruct(t *itype) bool { return t.TypeOf().Kind() == reflect.Struct }
 
-func isBool(t *itype) bool {
-	switch t.TypeOf().Kind() {
-	case reflect.Bool:
-		return true
-	case reflect.Chan:
-		return t.TypeOf().Elem().Kind() == reflect.Bool
-	default:
-		return false
-	}
-}
+func isBool(t *itype) bool { return t.TypeOf().Kind() == reflect.Bool }
 
 func isInt(t reflect.Type) bool {
 	switch t.Kind() {


### PR DESCRIPTION
Add condition type check in post-processing of CFG for
if and for statements. Add an isBool() helper function
which also accepts boolean channel values.

Fixes #438