### PR TITLE
fix: handle selector expression in type switch

### DIFF
--- a/_test/switch21.go
+++ b/_test/switch21.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func main() {
+	var err error
+
+	switch v := err.(type) {
+	case fmt.Formatter:
+		println("formatter")
+	default:
+		fmt.Println(v)
+	}
+}
+
+// Output:
+// <nil>

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -173,6 +173,10 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 					switch sym, _, ok := sc.lookup(n.child[0].ident); {
 					case ok && sym.kind == typeSym:
 						typ = sym.typ
+					case n.child[0].kind == selectorExpr:
+						if typ, err = nodeType(interp, sc, n.child[0]); err != nil {
+							return false
+						}
 					case n.child[0].ident == "nil":
 						typ = sc.getType("interface{}")
 					default:


### PR DESCRIPTION
For imported packages, types are defined by a selector expression
instead of an identificator (i.e. fmt.Formatter). Add support for
selector in type switch clause parsing.

Fixes partially #424 (in combination with #440)