### PR TITLE
fix: handle nil function closure

### DIFF
--- a/_test/fun10.go
+++ b/_test/fun10.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func f() func() {
+	return nil
+}
+
+func main() {
+	g := f()
+	fmt.Printf("%T %v\n", g, g)
+	if g == nil {
+		fmt.Println("nil func")
+	}
+}
+
+// Output:
+// func() <nil>
+// nil func

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1035,7 +1035,12 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 					if typ, err = nodeType(interp, sc, f.child[2].child[1].child[i].lastChild()); err != nil {
 						return
 					}
-					c.rval = reflect.New(typ.TypeOf()).Elem()
+					if typ.cat == funcT {
+						// Wrap the typed nil value in a node, as per other interpreter functions
+						c.rval = reflect.ValueOf(&node{kind: basicLit, rval: reflect.New(typ.TypeOf()).Elem()})
+					} else {
+						c.rval = reflect.New(typ.TypeOf()).Elem()
+					}
 				}
 			}
 

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -156,6 +156,14 @@ func TestEvalNil(t *testing.T) {
 			src: "Hello()",
 			res: "<nil>",
 		},
+		{
+			desc: "return nil func",
+			pre: func() {
+				eval(t, i, `func Bar() func() { return nil }`)
+			},
+			src: "Bar()",
+			res: "<nil>",
+		},
 	})
 }
 

--- a/interp/run.go
+++ b/interp/run.go
@@ -428,6 +428,10 @@ func _panic(n *node) {
 func genFunctionWrapper(n *node) func(*frame) reflect.Value {
 	var def *node
 	var ok bool
+
+	if n.kind == basicLit {
+		return func(f *frame) reflect.Value { return n.rval }
+	}
 	if def, ok = n.val.(*node); !ok {
 		return genValueAsFunctionWrapper(n)
 	}
@@ -2359,7 +2363,12 @@ func slice0(n *node) {
 }
 
 func isNil(n *node) {
-	value := genValue(n.child[0])
+	var value func(*frame) reflect.Value
+	if n.child[0].typ.cat == funcT {
+		value = genValueAsFunctionWrapper(n.child[0])
+	} else {
+		value = genValue(n.child[0])
+	}
 	tnext := getExec(n.tnext)
 
 	if n.fnext != nil {
@@ -2380,7 +2389,12 @@ func isNil(n *node) {
 }
 
 func isNotNil(n *node) {
-	value := genValue(n.child[0])
+	var value func(*frame) reflect.Value
+	if n.child[0].typ.cat == funcT {
+		value = genValueAsFunctionWrapper(n.child[0])
+	} else {
+		value = genValue(n.child[0])
+	}
 	tnext := getExec(n.tnext)
 
 	if n.fnext != nil {

--- a/interp/run.go
+++ b/interp/run.go
@@ -1354,6 +1354,8 @@ func _return(n *node) {
 			} else {
 				values[i] = genValue(c)
 			}
+		case funcT:
+			values[i] = genValue(c)
 		case interfaceT:
 			values[i] = genValueInterface(c)
 		default:

--- a/interp/value.go
+++ b/interp/value.go
@@ -55,9 +55,15 @@ func genValueRecv(n *node) func(*frame) reflect.Value {
 }
 
 func genValueAsFunctionWrapper(n *node) func(*frame) reflect.Value {
-	v := genValue(n)
+	value := genValue(n)
+	typ := n.typ.TypeOf()
+
 	return func(f *frame) reflect.Value {
-		return genFunctionWrapper(v(f).Interface().(*node))(f)
+		v := value(f)
+		if v.IsNil() {
+			return reflect.New(typ).Elem()
+		}
+		return genFunctionWrapper(v.Interface().(*node))(f)
 	}
 }
 


### PR DESCRIPTION
When generating a nil function, wrap a typed nil value in a node
so it can be handled as other interpreter functions.
Test nil value on wrapper rather than on non-nil node wrapper.

Fixes #437