### PR TITLE
fix: improve type switch clause with assign

### DIFF
--- a/_test/switch22.go
+++ b/_test/switch22.go
@@ -1,0 +1,21 @@
+package main
+
+type T struct {
+	Name string
+}
+
+func f(t interface{}) {
+	switch ext := t.(type) {
+	case *T:
+		println("*T", ext.Name)
+	default:
+		println("unknown")
+	}
+}
+
+func main() {
+	f(&T{"truc"})
+}
+
+// Output:
+// *T truc


### PR DESCRIPTION
Use node.isType() to check the type status of case clause,
simpler and more robust logic.

Fixes #449