### PR TITLE
fix: implicit import package name was not correctly generated

### DIFF
--- a/_test/foo-bar/foo-bar.go
+++ b/_test/foo-bar/foo-bar.go
@@ -1,0 +1,3 @@
+package bar
+
+var Name = "foo-bar"

--- a/_test/import7.go
+++ b/_test/import7.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/containous/yaegi/_test/foo-bar"
+
+func main() {
+	println(bar.Name)
+}
+
+// Output:
+// foo-bar

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -32,7 +32,7 @@ var constBltn = map[string]func(*node){
 	"real":    realConst,
 }
 
-var identifier = regexp.MustCompile("([\\pL_][\\pL_\\d]*)$")
+var identifier = regexp.MustCompile(`([\pL_][\pL_\d]*)$`)
 
 // cfg generates a control flow graph (CFG) from AST (wiring successors in AST)
 // and pre-compute frame sizes and indexes for all un-named (temporary) and named

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"path"
 	"reflect"
+	"regexp"
 	"unicode"
 )
 
@@ -31,6 +31,8 @@ var constBltn = map[string]func(*node){
 	"imag":    imagConst,
 	"real":    realConst,
 }
+
+var identifier = regexp.MustCompile("([\\pL_][\\pL_\\d]*)$")
 
 // cfg generates a control flow graph (CFG) from AST (wiring successors in AST)
 // and pre-compute frame sizes and indexes for all un-named (temporary) and named
@@ -316,7 +318,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 				name = n.child[0].ident
 			} else {
 				ipath = n.child[0].rval.String()
-				name = path.Base(ipath)
+				name = identifier.FindString(ipath)
 			}
 			if interp.binPkg[ipath] != nil && name != "." {
 				sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath}}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -1,7 +1,6 @@
 package interp
 
 import (
-	"path"
 	"reflect"
 )
 
@@ -126,7 +125,7 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 				name = n.child[0].ident
 			} else {
 				ipath = n.child[0].rval.String()
-				name = path.Base(ipath)
+				name = identifier.FindString(ipath)
 			}
 			// Try to import a binary package first, or a source package
 			if interp.binPkg[ipath] != nil {


### PR DESCRIPTION
In import statement, the implicit package name must be a valid
go identifier, even if the base name of the package path includes
non-letter characters.

This change extract the package name from a regular expression
matching an identifier conform to the Go specification.

Partly fixes #455