### PR TITLE
fix: struct type detection, collision between field and type name

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1536,7 +1536,7 @@ func (n *node) isType(sc *scope) bool {
 		}
 	case selectorExpr:
 		pkg, name := n.child[0].ident, n.child[1].ident
-		if sym, _, ok := sc.lookup(pkg); ok {
+		if sym, _, ok := sc.lookup(pkg); ok && sym.kind == pkgSym {
 			path := sym.typ.path
 			if p, ok := n.interp.binPkg[path]; ok && isBinType(p[name]) {
 				return true // Imported binary type

--- a/interp/type.go
+++ b/interp/type.go
@@ -401,6 +401,9 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				t.method = m
 				sym.typ = t
 			}
+			if t.node == nil {
+				t.node = n
+			}
 		} else {
 			t.incomplete = true
 			sc.sym[n.ident] = &symbol{kind: typeSym, typ: t}
@@ -995,7 +998,11 @@ func isInterface(t *itype) bool {
 	return isInterfaceSrc(t) || t.TypeOf().Kind() == reflect.Interface
 }
 
-func isStruct(t *itype) bool { return t.TypeOf().Kind() == reflect.Struct }
+func isStruct(t *itype) bool {
+	// Test first for a struct category, because a recursive interpreter struct may be
+	// represented by an interface{} at reflect level.
+	return t.cat == structT || t.TypeOf().Kind() == reflect.Struct
+}
 
 func isBool(t *itype) bool { return t.TypeOf().Kind() == reflect.Bool }
 


### PR DESCRIPTION
When checking if a node is a struct, test first the type category
to avoid missing recursive struct emulated by interface{}.

Avoid collision between type and field name in imported packages
by ensuring package selectors checks are applied on package symbols
only.

Fixes #455