### PR TITLE
fix: apply automatic type conversion to constant expressions

### DIFF
--- a/_test/bin2.go
+++ b/_test/bin2.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+func main() {
+	fmt.Println(math.Abs(-5))
+}
+
+// Output:
+// 5


### PR DESCRIPTION
Detect the presence of constant expression for unary operators and
perform computation of result during compile stage instead of exec
stage. It was already done correctly for binary operators.

Apply automatic type conversion not only to literal values but
also to arbitrary expressions where all members derive from a
predefined constant at compile stage.

Fixes #470