### PR TITLE
fix: continue statement was not applied correctly

### DIFF
--- a/_test/for8.go
+++ b/_test/for8.go
@@ -1,0 +1,18 @@
+package main
+
+func main() {
+	for i := 0; i < 4; i++ {
+		for {
+			break
+		}
+		if i == 1 {
+			continue
+		}
+		println(i)
+	}
+}
+
+// Output:
+// 0
+// 2
+// 3

--- a/_test/primes.go
+++ b/_test/primes.go
@@ -1,0 +1,26 @@
+package main
+
+func Primes(n int) int {
+	var xs []int
+	for i := 2; len(xs) < n; i++ {
+		ok := true
+		for _, x := range xs {
+			if i%x == 0 {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		xs = append(xs, i)
+	}
+	return xs[n-1]
+}
+
+func main() {
+	println(Primes(3))
+}
+
+// Output:
+// 5

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -74,12 +74,14 @@ type symbol struct {
 // execution to the index in frame, created exactly from the types layout.
 //
 type scope struct {
-	anc    *scope             // Ancestor upper scope
-	def    *node              // function definition node this scope belongs to, or nil
-	types  []reflect.Type     // Frame layout, may be shared by same level scopes
-	level  int                // Frame level: number of frame indirections to access var during execution
-	sym    map[string]*symbol // Map of symbols defined in this current scope
-	global bool               // true if scope refers to global space (single frame for universe and package level scopes)
+	anc         *scope             // Ancestor upper scope
+	def         *node              // function definition node this scope belongs to, or nil
+	loop        *node              // loop exit node for break statement
+	loopRestart *node              // loop restart node for continue statement
+	types       []reflect.Type     // Frame layout, may be shared by same level scopes
+	level       int                // Frame level: number of frame indirections to access var during execution
+	sym         map[string]*symbol // Map of symbols defined in this current scope
+	global      bool               // true if scope refers to global space (single frame for universe and package level scopes)
 }
 
 // push creates a new scope and chain it to the current one
@@ -95,6 +97,8 @@ func (s *scope) push(indirect bool) *scope {
 		sc.global = s.global
 		sc.level = s.level
 	}
+	// inherit loop state from ancestor
+	sc.loop, sc.loopRestart = s.loop, s.loopRestart
 	return &sc
 }
 


### PR DESCRIPTION
During CFG, store internal state for break and continue statements in
scope instead of global, to avoid corruption due to nested loops.

Fixes #450