### PR TITLE
fix: handle binary methods where receiver is implicit

### DIFF
--- a/_test/method29.go
+++ b/_test/method29.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 )
 
 var lookupHost = net.DefaultResolver.LookupHost
 
 func main() {
-	fmt.Println(lookupHost(context.Background(), "localhost"))
+	res, err := lookupHost(context.Background(), "localhost")
+	println(len(res) > 0, err == nil)
 }
 
 // Output:
-// [::1 127.0.0.1] <nil>
+// true true

--- a/_test/method29.go
+++ b/_test/method29.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+var lookupHost = net.DefaultResolver.LookupHost
+
+func main() {
+	fmt.Println(lookupHost(context.Background(), "localhost"))
+}
+
+// Output:
+// [::1 127.0.0.1] <nil>

--- a/_test/method30.go
+++ b/_test/method30.go
@@ -1,0 +1,20 @@
+package main
+
+type T struct {
+	Name string
+}
+
+func (t *T) foo(a string) string {
+	return t.Name + a
+}
+
+var g = &T{"global"}
+
+var f = g.foo
+
+func main() {
+	println(f("-x"))
+}
+
+// Output:
+// global-x

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -410,7 +410,11 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 						if src.typ, err = nodeType(interp, sc, src); err != nil {
 							return
 						}
-						dest.typ = src.typ
+						if src.typ.isBinMethod {
+							dest.typ = &itype{cat: valueT, rtype: src.typ.methodCallType()}
+						} else {
+							dest.typ = src.typ
+						}
 					}
 					if dest.typ.sizedef {
 						dest.typ.size = arrayTypeLen(src)
@@ -1097,7 +1101,7 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 					n.val = method.Index
 					n.gen = getIndexBinMethod
 					n.recv = &receiver{node: n.child[0]}
-					n.typ = &itype{cat: valueT, rtype: method.Type}
+					n.typ = &itype{cat: valueT, rtype: method.Type, isBinMethod: true}
 				case n.typ.rtype.Kind() == reflect.Ptr:
 					if field, ok := n.typ.rtype.Elem().FieldByName(n.child[1].ident); ok {
 						n.typ = &itype{cat: valueT, rtype: field.Type}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -60,6 +60,9 @@ func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
 					err = n.cfgErrorf("use of untyped nil")
 					return false
 				}
+				if typ.isBinMethod {
+					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true}
+				}
 				sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
 				if n.anc.kind == constDecl {
 					sc.sym[dest.ident].kind = constSym

--- a/interp/run.go
+++ b/interp/run.go
@@ -828,7 +828,9 @@ func callBin(n *node) {
 	// method signature obtained from reflect.Type include receiver as 1st arg, except for interface types
 	rcvrOffset := 0
 	if recv := n.child[0].recv; recv != nil && recv.node.typ.TypeOf().Kind() != reflect.Interface {
-		rcvrOffset = 1
+		if funcType.NumIn() > len(child) {
+			rcvrOffset = 1
+		}
 	}
 
 	for i, c := range child {
@@ -867,7 +869,6 @@ func callBin(n *node) {
 			case interfaceT:
 				values = append(values, genValueInterfaceValue(c))
 			default:
-				//values = append(values, genValue(c))
 				values = append(values, genInterfaceWrapper(c, defType))
 			}
 		}


### PR DESCRIPTION
Do not attempt to pass the receiver as method first argument if
the binary method was obtained from a non-interface object
selector, as reflect returns in that case a function where the
receiver is implicit.

Fixes #488