### PR TITLE
fix: import different source packages with same base name

### DIFF
--- a/_test/b1/foo/foo.go
+++ b/_test/b1/foo/foo.go
@@ -1,0 +1,7 @@
+package foo
+
+import bar "github.com/containous/yaegi/_test/b2/foo"
+
+var Desc = "in b1/foo"
+
+var Desc2 = Desc + bar.Desc

--- a/_test/b2/foo/foo.go
+++ b/_test/b2/foo/foo.go
@@ -1,0 +1,3 @@
+package foo
+
+var Desc = "in b2/foo"

--- a/_test/import8.go
+++ b/_test/import8.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/containous/yaegi/_test/b1/foo"
+
+func main() {
+	println(foo.Desc)
+}
+
+// Output:
+// in b1/foo

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1787,13 +1787,6 @@ func getExec(n *node) bltn {
 	return n.exec
 }
 
-func fileNode(n *node) *node {
-	if n == nil || n.kind == fileStmt {
-		return n
-	}
-	return fileNode(n.anc)
-}
-
 // setExec recursively sets the node exec builtin function by walking the CFG
 // from the entry point (first node to exec).
 func setExec(n *node) {

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -42,8 +42,8 @@ var identifier = regexp.MustCompile(`([\pL_][\pL_\d]*)$`)
 // and pre-compute frame sizes and indexes for all un-named (temporary) and named
 // variables. A list of nodes of init functions is returned.
 // Following this pass, the CFG is ready to run
-func (interp *Interpreter) cfg(root *node) ([]*node, error) {
-	sc, pkgName := interp.initScopePkg(root)
+func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
+	sc := interp.initScopePkg(pkgID)
 	var initNodes []*node
 	var iotaValue int
 	var err error
@@ -901,10 +901,10 @@ func (interp *Interpreter) cfg(root *node) ([]*node, error) {
 			sc = sc.pop()
 			funcName := n.child[1].ident
 			if !isMethod(n) {
-				interp.scopes[pkgName].sym[funcName].index = -1 // to force value to n.val
-				interp.scopes[pkgName].sym[funcName].typ = n.typ
-				interp.scopes[pkgName].sym[funcName].kind = funcSym
-				interp.scopes[pkgName].sym[funcName].node = n
+				interp.scopes[pkgID].sym[funcName].index = -1 // to force value to n.val
+				interp.scopes[pkgID].sym[funcName].typ = n.typ
+				interp.scopes[pkgID].sym[funcName].kind = funcSym
+				interp.scopes[pkgID].sym[funcName].node = n
 			}
 
 		case funcLit:

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -8,8 +8,8 @@ import (
 // variables and functions symbols at package level, prior to CFG.
 // All function bodies are skipped. GTA is necessary to handle out of
 // order declarations and multiple source files packages.
-func (interp *Interpreter) gta(root *node, rpath string) ([]*node, error) {
-	sc, _ := interp.initScopePkg(root)
+func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error) {
+	sc := interp.initScopePkg(pkgID)
 	var err error
 	var iotaValue int
 	var revisit []*node

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -146,7 +146,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				default: // import symbols in package namespace
 					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath}}
 				}
-			} else if err = interp.importSrc(rpath, ipath, name); err == nil {
+			} else if err = interp.importSrc(rpath, ipath); err == nil {
 				sc.types = interp.universe.types
 				switch name {
 				case "_": // no import of symbols

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -283,7 +283,7 @@ func (interp *Interpreter) resizeFrame() {
 func (interp *Interpreter) main() *node {
 	interp.mutex.RLock()
 	defer interp.mutex.RUnlock()
-	if m, ok := interp.scopes[mainID]; ok && m.sym[mainID] != nil {
+	if m, ok := interp.scopes[interp.Name]; ok && m.sym[mainID] != nil {
 		return m.sym[mainID].node
 	}
 	return nil
@@ -308,18 +308,18 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 	}
 
 	// Global type analysis
-	revisit, err := interp.gta(root, pkgName)
+	revisit, err := interp.gta(root, pkgName, interp.Name)
 	if err != nil {
 		return res, err
 	}
 	for _, n := range revisit {
-		if _, err = interp.gta(n, pkgName); err != nil {
+		if _, err = interp.gta(n, pkgName, interp.Name); err != nil {
 			return res, err
 		}
 	}
 
 	// Annotate AST with CFG infos
-	initNodes, err := interp.cfg(root)
+	initNodes, err := interp.cfg(root, interp.Name)
 	if err != nil {
 		return res, err
 	}
@@ -336,7 +336,7 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 	interp.mutex.Lock()
 	if interp.universe.sym[pkgName] == nil {
 		// Make the package visible under a path identical to its name
-		interp.srcPkg[pkgName] = interp.scopes[pkgName].sym
+		interp.srcPkg[pkgName] = interp.scopes[interp.Name].sym
 		interp.universe.sym[pkgName] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: pkgName}}
 	}
 	interp.mutex.Unlock()

--- a/interp/src.go
+++ b/interp/src.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func (interp *Interpreter) importSrc(rPath, path, alias string) error {
+func (interp *Interpreter) importSrc(rPath, path string) error {
 	var dir string
 	var err error
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -176,7 +176,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 					}
 				} else {
 					// Evaluate constant array size expression
-					if _, err = interp.cfg(n.child[0]); err != nil {
+					if _, err = interp.cfg(n.child[0], sc.pkgID); err != nil {
 						return nil, err
 					}
 					t.incomplete = true


### PR DESCRIPTION
Use pkgID (the full import path) rather than just the basename as the key
of source packages map. It avoids false cycle detection when importing
a/b/foo and c/d/foo.

Fixes #492.