### PR TITLE
fix: correct behavior for rune and byte types

### DIFF
--- a/_test/type16.go
+++ b/_test/type16.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := uint8(15) ^ byte(0)
+	fmt.Printf("%T %v\n", a, a)
+}
+
+// Output:
+// uint8 15

--- a/_test/type17.go
+++ b/_test/type17.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := int32(15) ^ rune(0)
+	fmt.Printf("%T %v\n", a, a)
+}
+
+// Output:
+// int32 15

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -216,7 +216,7 @@ func initUniverse() *scope {
 	sc := &scope{global: true, sym: map[string]*symbol{
 		// predefined Go types
 		"bool":        {kind: typeSym, typ: &itype{cat: boolT, name: "bool"}},
-		"byte":        {kind: typeSym, typ: &itype{cat: byteT, name: "byte"}},
+		"byte":        {kind: typeSym, typ: &itype{cat: uint8T, name: "uint8"}},
 		"complex64":   {kind: typeSym, typ: &itype{cat: complex64T, name: "complex64"}},
 		"complex128":  {kind: typeSym, typ: &itype{cat: complex128T, name: "complex128"}},
 		"error":       {kind: typeSym, typ: &itype{cat: errorT, name: "error"}},
@@ -228,7 +228,7 @@ func initUniverse() *scope {
 		"int32":       {kind: typeSym, typ: &itype{cat: int32T, name: "int32"}},
 		"int64":       {kind: typeSym, typ: &itype{cat: int64T, name: "int64"}},
 		"interface{}": {kind: typeSym, typ: &itype{cat: interfaceT}},
-		"rune":        {kind: typeSym, typ: &itype{cat: runeT, name: "rune"}},
+		"rune":        {kind: typeSym, typ: &itype{cat: int32T, name: "int32"}},
 		"string":      {kind: typeSym, typ: &itype{cat: stringT, name: "string"}},
 		"uint":        {kind: typeSym, typ: &itype{cat: uintT, name: "uint"}},
 		"uint8":       {kind: typeSym, typ: &itype{cat: uint8T, name: "uint8"}},

--- a/interp/type.go
+++ b/interp/type.go
@@ -17,7 +17,6 @@ const (
 	binPkgT
 	boolT
 	builtinT
-	byteT
 	chanT
 	complex64T
 	complex128T
@@ -33,7 +32,6 @@ const (
 	int64T
 	mapT
 	ptrT
-	runeT
 	srcPkgT
 	stringT
 	structT
@@ -54,7 +52,6 @@ var cats = [...]string{
 	arrayT:      "arrayT",
 	binT:        "binT",
 	binPkgT:     "binPkgT",
-	byteT:       "byteT",
 	boolT:       "boolT",
 	builtinT:    "builtinT",
 	chanT:       "chanT",
@@ -72,7 +69,6 @@ var cats = [...]string{
 	int64T:      "int64T",
 	mapT:        "mapT",
 	ptrT:        "ptrT",
-	runeT:       "runeT",
 	srcPkgT:     "srcPkgT",
 	stringT:     "stringT",
 	structT:     "structT",
@@ -200,8 +196,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			t.cat = boolT
 			t.name = "bool"
 		case byte:
-			t.cat = byteT
-			t.name = "byte"
+			t.cat = uint8T
+			t.name = "uint8"
 			t.untyped = true
 		case complex64:
 			t.cat = complex64T
@@ -227,8 +223,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			t.name = "uint"
 			t.untyped = true
 		case rune:
-			t.cat = runeT
-			t.name = "rune"
+			t.cat = int32T
+			t.name = "int32"
 			t.untyped = true
 		case string:
 			t.cat = stringT
@@ -594,7 +590,6 @@ var zeroValues [maxT]reflect.Value
 
 func init() {
 	zeroValues[boolT] = reflect.ValueOf(false)
-	zeroValues[byteT] = reflect.ValueOf(byte(0))
 	zeroValues[complex64T] = reflect.ValueOf(complex64(0))
 	zeroValues[complex128T] = reflect.ValueOf(complex128(0))
 	zeroValues[errorT] = reflect.ValueOf(new(error)).Elem()
@@ -605,7 +600,6 @@ func init() {
 	zeroValues[int16T] = reflect.ValueOf(int16(0))
 	zeroValues[int32T] = reflect.ValueOf(int32(0))
 	zeroValues[int64T] = reflect.ValueOf(int64(0))
-	zeroValues[runeT] = reflect.ValueOf(rune(0))
 	zeroValues[stringT] = reflect.ValueOf("")
 	zeroValues[uintT] = reflect.ValueOf(uint(0))
 	zeroValues[uint8T] = reflect.ValueOf(uint8(0))


### PR DESCRIPTION
Define byte as an alias to uint8 and rune as an alias to int32,
as per Go specification, instead of defining byte and rune as separate
types.

Fixes #505