### PR TITLE
fix: correct type inference in composite literal init

### DIFF
--- a/_test/composite5.go
+++ b/_test/composite5.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+type T struct {
+	m uint16
+}
+
+var t = T{1<<2 | 1<<3}
+
+func main() {
+	fmt.Println(t)
+}
+
+// Output:
+// {12}

--- a/_test/composite6.go
+++ b/_test/composite6.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/containous/yaegi/_test/ct1"
+)
+
+type T struct {
+	m uint16
+}
+
+var t = T{1 << ct1.R}
+
+func main() {
+	fmt.Println(t)
+}
+
+// Output:
+// {2}

--- a/_test/ct1/ct1.go
+++ b/_test/ct1/ct1.go
@@ -1,0 +1,9 @@
+package ct1
+
+type Class uint
+
+const (
+	L Class = iota
+	R
+	AL
+)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -231,7 +231,13 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			}
 			// Propagate type to children, to handle implicit types
 			for _, c := range n.child {
-				c.typ = n.typ
+				switch c.kind {
+				case binaryExpr, unaryExpr:
+					// Do not attempt to propagate composite type to operator expressions,
+					// it breaks constant folding.
+				default:
+					c.typ = n.typ
+				}
 			}
 
 		case forStmt0, forRangeStmt:
@@ -1175,6 +1181,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					n.gen = nop
 					n.typ = sym.typ
 					n.sym = sym
+					n.rval = sym.rval
 				} else {
 					err = n.cfgErrorf("undefined selector: %s.%s", pkg, name)
 				}


### PR DESCRIPTION
Avoid type interference when setting values from expressions
involving operators. Make sure to propagate constant values from
source packages for constant folding.

Fixes #507