### PR TITLE
fix: correctly handle constant init for further type declarations

### DIFF
--- a/_test/const6.go
+++ b/_test/const6.go
@@ -1,0 +1,22 @@
+package main
+
+const (
+	maxNonStarters = 30
+	maxBufferSize  = maxNonStarters + 2
+)
+
+type reorderBuffer struct {
+	rune [maxBufferSize]Properties
+}
+
+type Properties struct {
+	pos  uint8
+	size uint8
+}
+
+func main() {
+	println(len(reorderBuffer{}.rune))
+}
+
+// Output:
+// 32

--- a/_test/const7.go
+++ b/_test/const7.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+const (
+	a = iota
+	b
+	c
+	d
+)
+
+type T [c]int
+
+func main() {
+	fmt.Println(T{})
+}
+
+// Output:
+// [0 0]

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -75,8 +75,6 @@ const (
 	parenExpr
 	rangeStmt
 	returnStmt
-	rvalueExpr
-	rtypeExpr
 	selectStmt
 	selectorExpr
 	selectorImport
@@ -154,8 +152,6 @@ var kinds = [...]string{
 	parenExpr:        "parenExpr",
 	rangeStmt:        "rangeStmt",
 	returnStmt:       "returnStmt",
-	rvalueExpr:       "rvalueExpr",
-	rtypeExpr:        "rtypeExpr",
 	selectStmt:       "selectStmt",
 	selectorExpr:     "selectorExpr",
 	selectorImport:   "selectorImport",

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -21,6 +21,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 		switch n.kind {
 		case constDecl:
 			iotaValue = 0
+			_, err = interp.cfg(n, pkgID)
 
 		case blockStmt:
 			if n != root {
@@ -63,7 +64,9 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				if typ.isBinMethod {
 					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true}
 				}
-				sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
+				if sc.sym[dest.ident] == nil {
+					sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
+				}
 				if n.anc.kind == constDecl {
 					sc.sym[dest.ident].kind = constSym
 					iotaValue++

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -21,6 +21,8 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 		switch n.kind {
 		case constDecl:
 			iotaValue = 0
+			// Early parse of constDecl subtree, to compute all constant
+			// values which may be necessary in further declarations.
 			_, err = interp.cfg(n, pkgID)
 
 		case blockStmt:

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -78,11 +78,11 @@ func TestEvalBuiltin(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{
 		{src: `a := []int{}; a = append(a, 1); a`, res: "[1]"},
-		{src: `a := []int{1}; a = append(a, 2, 3); a`, res: "[1 2 3]"},
-		{src: `a := []int{1}; b := []int{2, 3}; a = append(a, b...); a`, res: "[1 2 3]"},
+		{src: `b := []int{1}; b = append(a, 2, 3); b`, res: "[1 2 3]"},
+		{src: `c := []int{1}; d := []int{2, 3}; c = append(c, d...); c`, res: "[1 2 3]"},
 		{src: `string(append([]byte("hello "), "world"...))`, res: "hello world"},
-		{src: `a := "world"; string(append([]byte("hello "), a...))`, res: "hello world"},
-		{src: `a := []byte("Hello"); copy(a, "world"); string(a)`, res: "world"},
+		{src: `e := "world"; string(append([]byte("hello "), e...))`, res: "hello world"},
+		{src: `f := []byte("Hello"); copy(f, "world"); string(f)`, res: "world"},
 	})
 }
 

--- a/interp/value.go
+++ b/interp/value.go
@@ -90,9 +90,6 @@ func genValue(n *node) func(*frame) reflect.Value {
 			v = reflect.ValueOf(n.val)
 		}
 		return func(f *frame) reflect.Value { return v }
-	case rvalueExpr:
-		v := n.rval
-		return func(f *frame) reflect.Value { return v }
 	default:
 		if n.rval.IsValid() {
 			v := n.rval


### PR DESCRIPTION
The value of constants is now computed early in global type analysis,
in order to complete parsing where constants are used in type
definition. This is achieved by invoking interp.cfg() on the constant
declaration subtree.

Obsolete rtypeExpr and rvalueExpr node kinds are suppressed.

In TestEvalBuiltin, use separate variables to avoid interferences
between declarations, as the test cases use the same interpreter
context.

Fixes #510