### PR TITLE
fix: correctly handle arbitrary type of literal array index

### DIFF
--- a/_test/a40.go
+++ b/_test/a40.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+type rule uint8
+
+const (
+	r0 rule = iota
+	r1
+	r2
+)
+
+var a = [...]int{
+	r0: 1,
+	r1: 12,
+}
+
+func main() {
+	fmt.Println(a)
+}
+
+// Output:
+// [1 12]

--- a/interp/run.go
+++ b/interp/run.go
@@ -1461,7 +1461,7 @@ func arrayLit(n *node) {
 		if c.kind == keyValueExpr {
 			convertLiteralValue(c.child[1], rtype)
 			values[i] = genValue(c.child[1])
-			index[i] = int(c.child[0].rval.Int())
+			index[i] = int(vInt(c.child[0].rval))
 		} else {
 			convertLiteralValue(c, rtype)
 			values[i] = genValue(c)


### PR DESCRIPTION
Convert the numerical index value to int according to its source
type.

Fixes #513