### PR TITLE
fix: didn't set values after calculation while there is a fnext branch

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -245,6 +245,76 @@ func f() string {
 	}
 }
 
+func TestEvalStruct2(t *testing.T) {
+	i := interp.New(interp.Options{})
+	eval(t, i, `
+type Fromage struct {
+	Done bool
+}
+
+func f() bool {
+	a := Fromage{
+		true,
+	}
+
+	return a.Done && true
+}
+`)
+
+	v := eval(t, i, `f()`)
+	time.Sleep(time.Second)
+	if v.Interface().(bool) != true {
+		t.Fatalf("got %v, want true", v)
+	}
+}
+
+func TestEvalStruct3(t *testing.T) {
+	i := interp.New(interp.Options{})
+	eval(t, i, `
+type Fromage struct {
+	Done bool
+}
+
+func f() bool {
+	a := &Fromage{
+		true,
+	}
+
+	return a.Done && true
+}
+`)
+
+	v := eval(t, i, `f()`)
+	time.Sleep(time.Second)
+	if v.Interface().(bool) != true {
+		t.Fatalf("got %v, want true", v)
+	}
+}
+
+func TestEvalStruct4(t *testing.T) {
+	i := interp.New(interp.Options{})
+	eval(t, i, `
+type Fromage struct {
+	Done *bool
+}
+
+func f() bool {
+	t := true
+	a := &Fromage{
+		&t,
+	}
+
+	return *(a.Done) && true
+}
+`)
+
+	v := eval(t, i, `f()`)
+	time.Sleep(time.Second)
+	if v.Interface().(bool) != true {
+		t.Fatalf("got %v, want true", v)
+	}
+}
+
 func TestEvalComposite0(t *testing.T) {
 	i := interp.New(interp.Options{})
 	eval(t, i, `

--- a/interp/run.go
+++ b/interp/run.go
@@ -391,8 +391,10 @@ func deref(n *node) {
 	tnext := getExec(n.tnext)
 
 	if n.fnext != nil {
+		i := n.findex
 		fnext := getExec(n.fnext)
 		n.exec = func(f *frame) bltn {
+			f.data[i] = value(f).Elem()
 			if value(f).Elem().Bool() {
 				return tnext
 			}
@@ -1157,8 +1159,10 @@ func getIndexSeq(n *node) {
 	tnext := getExec(n.tnext)
 
 	if n.fnext != nil {
+		i := n.findex
 		fnext := getExec(n.fnext)
 		n.exec = func(f *frame) bltn {
+			f.data[i] = value(f).FieldByIndex(index)
 			if value(f).FieldByIndex(index).Bool() {
 				return tnext
 			}
@@ -1185,8 +1189,10 @@ func getPtrIndexSeq(n *node) {
 	}
 
 	if n.fnext != nil {
+		i := n.findex
 		fnext := getExec(n.fnext)
 		n.exec = func(f *frame) bltn {
+			f.data[i] = value(f).Elem().FieldByIndex(index)
 			if value(f).Elem().FieldByIndex(index).Bool() {
 				return tnext
 			}


### PR DESCRIPTION
I don't know if this method is the right way according to your code style. 
If this is really useful for fixing those bugs, I'm sure that there are lots of similar code blocks that need to be fixed which you can search by keyword `if n.fnext != nil`.


The following program sample.go triggers an unexpected error:
```
package main
type Fromage struct {
	Done bool
}

func main() {
	a := Fromage{
		true,
	}

	println( a.Done && true )
}
```
Expected result:

$ go run ./sample.go
true

Got:

$ yaegi ./sample.go
false