### PR TITLE
fix: re-apply GTA until all global types/constants are defined

### DIFF
--- a/_test/assign1.go
+++ b/_test/assign1.go
@@ -9,5 +9,5 @@ func main() {
 	fmt.Println(buf)
 }
 
-// Output
+// Output:
 // []

--- a/_test/bad0.go
+++ b/_test/bad0.go
@@ -1,4 +1,4 @@
 println("Hello")
 
 // Error:
-// _test/bad0.go:1:1: expected 'package', found println
+// 1:1: expected 'package', found println

--- a/_test/complex3.go
+++ b/_test/complex3.go
@@ -7,5 +7,5 @@ func main() {
 	fmt.Printf("%T %v\n", s, s)
 }
 
-// Output
+// Output:
 // int 2

--- a/_test/const10.go
+++ b/_test/const10.go
@@ -1,0 +1,17 @@
+package main
+
+const (
+	a = 2
+	b = c + d
+	c = a + d
+	d = e + f
+	e = 3
+	f = 4
+)
+
+func main() {
+	println(b)
+}
+
+// Output:
+// 16

--- a/_test/const8.go
+++ b/_test/const8.go
@@ -1,0 +1,15 @@
+package main
+
+const (
+	a = 2
+	b = c + d
+	c = 4
+	d = 5
+)
+
+func main() {
+	println(a, b, c, d)
+}
+
+// Output:
+// 2 9 4 5

--- a/_test/const9.go
+++ b/_test/const9.go
@@ -1,0 +1,17 @@
+package main
+
+const (
+	a = 2
+	b = c + d
+	c = a + d
+	d = e + f
+	e = b + 2
+	f = 4
+)
+
+func main() {
+	println(b)
+}
+
+// Error:
+// 5:2: constant definition loop

--- a/_test/map19.go
+++ b/_test/map19.go
@@ -14,3 +14,6 @@ func main() {
 	m := cmap{}
 	fmt.Println(m)
 }
+
+// Output:
+// {map[]}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -10,7 +10,12 @@ import (
 )
 
 // A cfgError represents an error during CFG build stage
-type cfgError error
+type cfgError struct {
+	*node
+	error
+}
+
+func (c *cfgError) Error() string { return c.error.Error() }
 
 var constOp = map[action]func(*node){
 	aAdd:    addConst,
@@ -1539,13 +1544,13 @@ func childPos(n *node) int {
 	return -1
 }
 
-func (n *node) cfgErrorf(format string, a ...interface{}) cfgError {
+func (n *node) cfgErrorf(format string, a ...interface{}) *cfgError {
 	a = append([]interface{}{n.interp.fset.Position(n.pos)}, a...)
-	return cfgError(fmt.Errorf("%s: "+format, a...))
+	return &cfgError{n, fmt.Errorf("%s: "+format, a...)}
 }
 
 func genRun(nod *node) error {
-	var err cfgError
+	var err error
 
 	nod.Walk(func(n *node) bool {
 		if err != nil {

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -23,8 +23,10 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 			iotaValue = 0
 			// Early parse of constDecl subtree, to compute all constant
 			// values which may be necessary in further declarations.
-			// No error processing here, to allow recovery in subtree nodes.
-			interp.cfg(n, pkgID)
+			if _, err = interp.cfg(n, pkgID); err != nil {
+				// No error processing here, to allow recovery in subtree nodes.
+				err = nil
+			}
 
 		case blockStmt:
 			if n != root {
@@ -225,11 +227,11 @@ func (interp *Interpreter) gtaRetry(nodes []*node, rpath, pkgID string) error {
 	revisit := []*node{}
 	for {
 		for _, n := range nodes {
-			v, err := interp.gta(n, rpath, pkgID)
+			list, err := interp.gta(n, rpath, pkgID)
 			if err != nil {
 				return err
 			}
-			revisit = append(revisit, v...)
+			revisit = append(revisit, list...)
 		}
 
 		if len(revisit) == 0 || equalNodes(nodes, revisit) {
@@ -246,7 +248,7 @@ func (interp *Interpreter) gtaRetry(nodes []*node, rpath, pkgID string) error {
 	return nil
 }
 
-// equalNodes returns true if two slices of nodes are identical
+// equalNodes returns true if two slices of nodes are identical.
 func equalNodes(a, b []*node) bool {
 	if len(a) != len(b) {
 		return false

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -294,7 +294,7 @@ func (interp *Interpreter) main() *node {
 func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 	var res reflect.Value
 
-	// Parse source to AST
+	// Parse source to AST.
 	pkgName, root, err := interp.ast(src, interp.Name)
 	if err != nil || root == nil {
 		return res, err
@@ -307,15 +307,9 @@ func (interp *Interpreter) Eval(src string) (reflect.Value, error) {
 		}
 	}
 
-	// Global type analysis
-	revisit, err := interp.gta(root, pkgName, interp.Name)
-	if err != nil {
+	// Perform global types analysis.
+	if err = interp.gtaRetry([]*node{root}, pkgName, interp.Name); err != nil {
 		return res, err
-	}
-	for _, n := range revisit {
-		if _, err = interp.gta(n, pkgName, interp.Name); err != nil {
-			return res, err
-		}
 	}
 
 	// Annotate AST with CFG infos

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -33,6 +33,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 	for _, file := range files {
 		if filepath.Ext(file.Name()) != ".go" ||
 			file.Name() == "bad0.go" || // expect error
+			file.Name() == "const9.go" || // expect error
 			file.Name() == "export1.go" || // non-main package
 			file.Name() == "export0.go" || // non-main package
 			file.Name() == "for7.go" || // expect error
@@ -137,6 +138,11 @@ func TestInterpErrorConsistency(t *testing.T) {
 			fileName:       "bad0.go",
 			expectedInterp: "1:1: expected 'package', found println",
 			expectedExec:   "1:1: expected 'package', found println",
+		},
+		{
+			fileName:       "const9.go",
+			expectedInterp: "5:2: constant definition loop",
+			expectedExec:   "5:2: constant definition loop",
 		},
 		{
 			fileName:       "if2.go",

--- a/interp/src.go
+++ b/interp/src.go
@@ -47,7 +47,7 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 	var root *node
 	var pkgName string
 
-	// Parse source files
+	// Parse source files.
 	for _, file := range files {
 		name := file.Name()
 		if skipFile(&interp.context, name) {
@@ -86,12 +86,10 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 		revisit[subRPath] = append(revisit[subRPath], list...)
 	}
 
-	// revisit incomplete nodes where GTA could not complete
+	// Revisit incomplete nodes where GTA could not complete.
 	for pkg, nodes := range revisit {
-		for _, n := range nodes {
-			if _, err = interp.gta(n, pkg, path); err != nil {
-				return err
-			}
+		if err = interp.gtaRetry(nodes, pkg, path); err != nil {
+			return err
 		}
 	}
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -139,7 +139,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 		}
 	}
 
-	var err cfgError
+	var err error
 	switch n.kind {
 	case addressExpr, starExpr:
 		t.cat = ptrT
@@ -614,7 +614,7 @@ func init() {
 
 // if type is incomplete, re-parse it.
 func (t *itype) finalize() (*itype, error) {
-	var err cfgError
+	var err error
 	if t.incomplete {
 		sym, _, found := t.scope.lookup(t.name)
 		if found && !sym.typ.incomplete {


### PR DESCRIPTION
Depending on how declarations are ordered, more than 1 retry of
Global Type Analysis pass may be required. The logic has been
changed to retry until all missing symbols are solved or a loop
definition is detected.

A few unit test has been fixed as well.

Fixes #515