### PR TITLE
fix: handle interface values in map and arrays

### DIFF
--- a/_test/interface20.go
+++ b/_test/interface20.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a interface{}
+	a = string("A")
+	fmt.Println(a)
+}
+
+// Output:
+// A

--- a/_test/interface21.go
+++ b/_test/interface21.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := make([]interface{}, 1)
+	s[0] = 1
+	fmt.Println(s[0])
+}
+
+// Output:
+// 1

--- a/_test/interface22.go
+++ b/_test/interface22.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := make([]interface{}, 0)
+	s = append(s, 1)
+	fmt.Println(s[0])
+}
+
+// Output:
+// 1

--- a/_test/interface23.go
+++ b/_test/interface23.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]interface{})
+	m["A"] = string("A")
+	fmt.Println(m["A"])
+}
+
+// Output:
+// A

--- a/_test/interface24.go
+++ b/_test/interface24.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]interface{})
+	fmt.Println(m["B"])
+}
+
+// Output:
+// <nil>

--- a/_test/interface25.go
+++ b/_test/interface25.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]interface{})
+	m["A"] = 1
+	for _, v := range m {
+		fmt.Println(v)
+	}
+}
+
+// Output:
+// 1

--- a/_test/interface26.go
+++ b/_test/interface26.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := make([]interface{}, 0)
+	s = append(s, 1)
+	for _, v := range s {
+		fmt.Println(v)
+	}
+}
+
+// Output:
+// 1

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -464,7 +464,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						err = n.cfgErrorf("illegal operand types for '%v' operator", n.action)
 					}
 				default:
-					// Detect invalid float truncate
+					// Detect invalid float truncate.
 					if isInt(t0) && isFloat(t1) {
 						err = src.cfgErrorf("invalid float truncate")
 						return
@@ -475,7 +475,8 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				// Propagate type
 				// TODO: Check that existing destination type matches source type
 				switch {
-				case n.action == aAssign && src.action == aCall:
+				case n.action == aAssign && src.action == aCall && dest.typ.cat != interfaceT:
+					// Call action may perform the assignment directly.
 					n.gen = nop
 					src.level = level
 					src.findex = dest.findex
@@ -483,7 +484,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						src.typ = dest.typ
 					}
 				case n.action == aAssign && src.action == aRecv:
-					// Assign by reading from a receiving channel
+					// Assign by reading from a receiving channel.
 					n.gen = nop
 					src.findex = dest.findex // Set recv address to LHS
 					dest.typ = src.typ
@@ -492,16 +493,16 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					src.findex = dest.findex
 					src.level = level
 				case src.kind == basicLit:
-					// TODO: perform constant folding and propagation here
+					// TODO: perform constant folding and propagation here.
 					switch {
 					case dest.typ.cat == interfaceT:
 					case isComplex(dest.typ.TypeOf()):
-						// value set in genValue
+						// Value set in genValue.
 					case !src.rval.IsValid():
-						// Assign to nil
+						// Assign to nil.
 						src.rval = reflect.New(dest.typ.TypeOf()).Elem()
 					default:
-						// Convert literal value to destination type
+						// Convert literal value to destination type.
 						src.rval = src.rval.Convert(dest.typ.TypeOf())
 						src.typ = dest.typ
 					}

--- a/interp/run.go
+++ b/interp/run.go
@@ -1830,14 +1830,26 @@ func rangeMap(n *node) {
 	if len(n.child) == 4 {
 		index1 := n.child[1].findex  // map value location in frame
 		value = genValue(n.child[2]) // map
-		n.exec = func(f *frame) bltn {
-			iter := f.data[index2].Interface().(*reflect.MapIter)
-			if !iter.Next() {
-				return fnext
+		if n.child[1].typ.cat == interfaceT {
+			n.exec = func(f *frame) bltn {
+				iter := f.data[index2].Interface().(*reflect.MapIter)
+				if !iter.Next() {
+					return fnext
+				}
+				f.data[index0].Set(iter.Key())
+				f.data[index1].Set(iter.Value().Elem())
+				return tnext
 			}
-			f.data[index0].Set(iter.Key())
-			f.data[index1].Set(iter.Value())
-			return tnext
+		} else {
+			n.exec = func(f *frame) bltn {
+				iter := f.data[index2].Interface().(*reflect.MapIter)
+				if !iter.Next() {
+					return fnext
+				}
+				f.data[index0].Set(iter.Key())
+				f.data[index1].Set(iter.Value())
+				return tnext
+			}
 		}
 	} else {
 		value = genValue(n.child[1]) // map


### PR DESCRIPTION
Correctly wrap values in interfaceValue in []interface{} and
map[]interface{} kind of types. Added related tests.

Fixes #527