### PR TITLE
fix: handle use of functions in struct fields

### DIFF
--- a/_test/struct32.go
+++ b/_test/struct32.go
@@ -1,0 +1,39 @@
+package main
+
+type T0 struct {
+	name string
+}
+
+type lookupFunc func(s string) T0
+
+type T1 struct {
+	name string
+	info lookupFunc
+}
+
+func (t T0) F1() bool { println("in F1"); return true }
+
+type T2 struct {
+	t1 T1
+}
+
+func (t2 *T2) f() {
+	info := t2.t1.info("foo")
+	println(info.F1())
+}
+
+var t0 = T0{"t0"}
+
+func main() {
+	t := &T2{T1{
+		"bar", func(s string) T0 { return t0 },
+	}}
+
+	println("hello")
+	println(t.t1.info("foo").F1())
+}
+
+// Output:
+// hello
+// in F1
+// true

--- a/_test/struct33.go
+++ b/_test/struct33.go
@@ -1,0 +1,43 @@
+package main
+
+type T0 struct {
+	name string
+}
+
+type lookupFunc func(s string) T0
+
+type T1 struct {
+	name string
+	info lookupFunc
+}
+
+func (t T0) F1() bool { println("in F1"); return true }
+
+type T2 struct {
+	t1 T1
+}
+
+func (t2 *T2) f() {
+	info := t2.t1.info("foo")
+	println(info.F1())
+}
+
+var t0 = T0{"t0"}
+
+func look(s string) T0 { println("in look"); return t0 }
+
+var table = []*T1{{
+	name: "bar",
+	info: look,
+},
+}
+
+func main() {
+	info := table[0].info
+	println(info("foo").F1())
+}
+
+// Output:
+// in look
+// in F1
+// true

--- a/_test/struct33.go
+++ b/_test/struct33.go
@@ -13,15 +13,6 @@ type T1 struct {
 
 func (t T0) F1() bool { println("in F1"); return true }
 
-type T2 struct {
-	t1 T1
-}
-
-func (t2 *T2) f() {
-	info := t2.t1.info("foo")
-	println(info.F1())
-}
-
 var t0 = T0{"t0"}
 
 func look(s string) T0 { println("in look"); return t0 }

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -777,7 +777,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			case isBinCall(n):
 				n.gen = callBin
 				if typ := n.child[0].typ.rtype; typ.NumOut() > 0 {
-					if funcType := internalFuncType(n.child[0]); funcType != nil {
+					if funcType := n.child[0].typ.val; funcType != nil {
 						// Use the original unwrapped function type, to allow future field and
 						// methods resolutions, otherwise impossible on the opaque bin type.
 						n.typ = funcType.ret[0]
@@ -1928,13 +1928,4 @@ func isValueUntyped(v reflect.Value) bool {
 	}
 	t := v.Type()
 	return t.String() == t.Kind().String()
-}
-
-// InternalFuncType returns an interpreter defined function type if matched, or nil.
-// It is meant to be called on binary function nodes to unwrap their original type.
-func internalFuncType(n *node) *itype {
-	if n.kind == selectorExpr && len(n.child) > 0 && n.child[0].typ.cat == structT {
-		return n.typ.val
-	}
-	return nil
 }

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -525,7 +525,11 @@ func eval(t *testing.T, i *interp.Interpreter, src string) reflect.Value {
 	t.Helper()
 	res, err := i.Eval(src)
 	if err != nil {
-		t.Fatal(err)
+		t.Logf("Error: %v", err)
+		if e, ok := err.(interp.Panic); ok {
+			t.Logf(string(e.Stack))
+		}
+		t.FailNow()
 	}
 	return res
 }
@@ -541,7 +545,11 @@ func assertEval(t *testing.T, i *interp.Interpreter, src, expectedError, expecte
 	}
 
 	if err != nil {
-		t.Fatalf("got an error %v", err)
+		t.Logf("got an error: %v", err)
+		if e, ok := err.(interp.Panic); ok {
+			t.Logf(string(e.Stack))
+		}
+		t.FailNow()
 	}
 
 	if fmt.Sprintf("%v", res) != expectedRes {

--- a/interp/src.go
+++ b/interp/src.go
@@ -3,6 +3,7 @@ package interp
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +61,7 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 			return err
 		}
 
+		log.Println("read", name)
 		var pname string
 		if pname, root, err = interp.ast(string(buf), name); err != nil {
 			return err

--- a/interp/src.go
+++ b/interp/src.go
@@ -3,7 +3,6 @@ package interp
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,7 +60,6 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 			return err
 		}
 
-		log.Println("read", name)
 		var pname string
 		if pname, root, err = interp.ast(string(buf), name); err != nil {
 			return err


### PR DESCRIPTION
Functions in struct fields are wrapped in binary functions, in
order to allow interchange between runtime and interpreter context.
But in this process, the original type of function returned objects
is lost (replaced by anonymous reflect types), making impossible to
perform method resolution (based on type names).

The solution to this problem is to "unwrap" struct field function
types, to preserve the necessary information, and to keep along
the original type reference.

Fixes #525