### PR TITLE
fix: correct control flow graph for defer statements

### DIFF
--- a/_test/defer4.go
+++ b/_test/defer4.go
@@ -1,0 +1,23 @@
+package main
+
+import "sync"
+
+type T struct {
+	mu   sync.RWMutex
+	name string
+}
+
+func (t *T) get() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.name
+}
+
+var d = T{name: "test"}
+
+func main() {
+	println(d.get())
+}
+
+// Output:
+// test

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -200,7 +200,6 @@ const (
 	aCase
 	aCompositeLit
 	aDec
-	aDefer
 	aEqual
 	aGreater
 	aGreaterEqual
@@ -258,7 +257,6 @@ var actions = [...]string{
 	aCase:         "case",
 	aCompositeLit: "compositeLit",
 	aDec:          "--",
-	aDefer:        "defer",
 	aEqual:        "==",
 	aGreater:      ">",
 	aGetFunc:      "getFunc",
@@ -569,7 +567,7 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 			st.push(addChild(&root, anc, pos, declStmt, aNop), nod)
 
 		case *ast.DeferStmt:
-			st.push(addChild(&root, anc, pos, deferStmt, aDefer), nod)
+			st.push(addChild(&root, anc, pos, deferStmt, aNop), nod)
 
 		case *ast.Ellipsis:
 			st.push(addChild(&root, anc, pos, ellipsisExpr, aNop), nod)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1132,7 +1132,6 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					}
 				case n.typ.rtype.Kind() == reflect.Struct:
 					if field, ok := n.typ.rtype.FieldByName(n.child[1].ident); ok {
-						log.Println(n.index, "selector bin method #2.1")
 						n.typ = &itype{cat: valueT, rtype: field.Type}
 						n.val = field.Index
 						n.gen = getIndexSeq
@@ -1140,7 +1139,6 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						// method lookup failed on type, now lookup on pointer to type
 						pt := reflect.PtrTo(n.typ.rtype)
 						if m2, ok2 := pt.MethodByName(n.child[1].ident); ok2 {
-							log.Println(n.index, "selector bin method #2.2")
 							n.val = m2.Index
 							n.gen = getIndexBinPtrMethod
 							n.typ = &itype{cat: valueT, rtype: m2.Type}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -936,7 +936,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			sc = sc.pop()
 			err = genRun(n)
 
-		case goStmt:
+		case deferStmt, goStmt:
 			wireChild(n)
 
 		case identExpr:
@@ -1132,6 +1132,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					}
 				case n.typ.rtype.Kind() == reflect.Struct:
 					if field, ok := n.typ.rtype.FieldByName(n.child[1].ident); ok {
+						log.Println(n.index, "selector bin method #2.1")
 						n.typ = &itype{cat: valueT, rtype: field.Type}
 						n.val = field.Index
 						n.gen = getIndexSeq
@@ -1139,6 +1140,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						// method lookup failed on type, now lookup on pointer to type
 						pt := reflect.PtrTo(n.typ.rtype)
 						if m2, ok2 := pt.MethodByName(n.child[1].ident); ok2 {
+							log.Println(n.index, "selector bin method #2.2")
 							n.val = m2.Index
 							n.gen = getIndexBinPtrMethod
 							n.typ = &itype{cat: valueT, rtype: m2.Type}

--- a/interp/run.go
+++ b/interp/run.go
@@ -668,8 +668,7 @@ func call(n *node) {
 	}
 
 	if n.anc.kind == deferStmt {
-		// Resolve function and input args, but instead of executing,
-		// store function call in frame for deferred execution.
+		// Store function call in frame for deferred execution.
 		value = genFunctionWrapper(n.child[0])
 		n.exec = func(f *frame) bltn {
 			val := make([]reflect.Value, len(values)+1)
@@ -868,8 +867,7 @@ func callBin(n *node) {
 
 	switch {
 	case n.anc.kind == deferStmt:
-		// Resolve function and input args, but instead of executing,
-		// store function call in frame for deferred execution.
+		// Store function call in frame for deferred execution.
 		n.exec = func(f *frame) bltn {
 			val := make([]reflect.Value, l+1)
 			val[0] = value(f)


### PR DESCRIPTION
The control flow graph was incorrect for defer statements, some
defer call dependencies could be missing. This is fixed by generating
the CFG in the same way as regular calls, and handling defered calls
in call generators.

Fixes #500.