### PR TITLE
fix: do not overwrite input for assign operators

### DIFF
--- a/_test/bin3.go
+++ b/_test/bin3.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	str := "part1"
+	str += fmt.Sprintf("%s", "part2")
+	fmt.Println(str)
+}
+
+// Output:
+// part1part2

--- a/interp/run.go
+++ b/interp/run.go
@@ -901,8 +901,10 @@ func callBin(n *node) {
 			return fnext
 		}
 	default:
-		switch n.anc.kind {
-		case defineStmt, assignStmt, defineXStmt, assignXStmt:
+		switch n.anc.action {
+		case aAssign, aAssignX:
+			// The function call is part of an assign expression, we write results direcly
+			// to assigned location, to avoid an additional assign operation.
 			rvalues := make([]func(*frame) reflect.Value, funcType.NumOut())
 			for i := range rvalues {
 				c := n.anc.child[i]


### PR DESCRIPTION
The optimisation to write the result of a function call directly
to variable location must not be enabled for assign operator
expressions such as "+=", "-=", etc. Just limit it to regular
assign expressions.

Fixes #541.