### PR TITLE
fix: correct control flow graph for constant conditional statements

### DIFF
--- a/_test/for10.go
+++ b/_test/for10.go
@@ -1,0 +1,13 @@
+package main
+
+func main() {
+	for a := 0; false; {
+		println("nok", a)
+		a++
+		break
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/for11.go
+++ b/_test/for11.go
@@ -1,0 +1,13 @@
+package main
+
+func main() {
+	a := 0
+	for ; true; a++ {
+		println("nok", a)
+		break
+	}
+	println("bye", a)
+}
+
+// Output:
+// bye

--- a/_test/for11.go
+++ b/_test/for11.go
@@ -11,4 +11,4 @@ func main() {
 
 // Output:
 // nok 0
-// bye
+// bye 0

--- a/_test/for12.go
+++ b/_test/for12.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	for a := 0; false; a++ {
+		println("nok", a)
+		break
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/for13.go
+++ b/_test/for13.go
@@ -2,7 +2,7 @@ package main
 
 func main() {
 	a := 0
-	for ; true; a++ {
+	for ; false; a++ {
 		println("nok", a)
 		break
 	}
@@ -10,5 +10,4 @@ func main() {
 }
 
 // Output:
-// nok 0
 // bye

--- a/_test/for13.go
+++ b/_test/for13.go
@@ -10,4 +10,4 @@ func main() {
 }
 
 // Output:
-// bye
+// bye 0

--- a/_test/for14.go
+++ b/_test/for14.go
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+	for a := 0; true; a++ {
+		println(a)
+		if a > 0 {
+			break
+		}
+	}
+	println("bye")
+}
+
+// Output:
+// 0
+// 1
+// bye

--- a/_test/for9.go
+++ b/_test/for9.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	for false {
+		println("nok")
+		break
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/if3.go
+++ b/_test/if3.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	a := 0
+	if false {
+		println("false")
+		a = 1
+	} else {
+		println("true")
+		a = -1
+	}
+	println(a)
+}
+
+// Output:
+// true
+// -1

--- a/_test/if4.go
+++ b/_test/if4.go
@@ -1,0 +1,19 @@
+package main
+
+const bad = false
+
+func main() {
+	a := 0
+	if bad {
+		println("false")
+		a = 1
+	} else {
+		println("true")
+		a = -1
+	}
+	println(a)
+}
+
+// Output:
+// true
+// -1

--- a/_test/if5.go
+++ b/_test/if5.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	if true {
+		println("ok")
+	}
+	println("bye")
+}
+
+// Output:
+// ok
+// bye

--- a/_test/if6.go
+++ b/_test/if6.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+	if false {
+		println("nok")
+	}
+	println("bye")
+}
+
+// Output:
+// bye


### PR DESCRIPTION
In case of a constant condition, determined during control flow graph
analysis (cfg.go), test and alternate branch are considered useless and
cand be avoided completely during execution by setting the node tnext
field accordingly. This both fixes the issue #553 and possible variants,
and optimize the generated closures.

Fixes #553.