### PR TITLE
fix: correct control flow graph for switch statement

### DIFF
--- a/_test/switch27.go
+++ b/_test/switch27.go
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+	//a := false
+	switch false {
+	case true:
+		println("true")
+	case false:
+		println("false")
+	}
+	println("bye")
+}
+
+// Output:
+// false
+// bye

--- a/_test/switch28.go
+++ b/_test/switch28.go
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	switch {
+	case true:
+		println("true")
+	case false:
+		println("false")
+	}
+	println("bye")
+}
+
+// Output:
+// true
+// bye

--- a/_test/switch29.go
+++ b/_test/switch29.go
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	a := 3
+	switch a {
+	case 3:
+		println("three")
+	}
+	println("bye")
+}
+
+// Output:
+// three
+// bye

--- a/_test/switch30.go
+++ b/_test/switch30.go
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+	a := 3
+	switch a {
+	default:
+		//println("default")
+	case 3:
+		println("three")
+	}
+	println("bye")
+}
+
+// Output:
+// three
+// bye

--- a/_test/switch31.go
+++ b/_test/switch31.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	switch {
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/switch32.go
+++ b/_test/switch32.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+	a := 1
+	switch a {
+	}
+	println("bye", a)
+}
+
+// Output:
+// bye 1

--- a/_test/switch33.go
+++ b/_test/switch33.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+	var a interface{}
+	switch a.(type) {
+	}
+	println("bye")
+}
+
+// Output:
+// bye


### PR DESCRIPTION
The CFG was not always correct for the last clause case, or
if the case body was empty. Several unit tests are added to
check all variants.

Fixes #560.