### PR TITLE
fix: correct comparison of interface type to nil

### DIFF
--- a/_test/interface29.go
+++ b/_test/interface29.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	var a interface{}
+	println(a == nil)
+}
+
+// Output:
+// true

--- a/_test/interface30.go
+++ b/_test/interface30.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	var a interface{}
+	println(a != nil)
+}
+
+// Output:
+// false

--- a/interp/run.go
+++ b/interp/run.go
@@ -2594,56 +2594,94 @@ func slice0(n *node) {
 
 func isNil(n *node) {
 	var value func(*frame) reflect.Value
-	if n.child[0].typ.cat == funcT {
-		value = genValueAsFunctionWrapper(n.child[0])
+	c0 := n.child[0]
+	if c0.typ.cat == funcT {
+		value = genValueAsFunctionWrapper(c0)
 	} else {
-		value = genValue(n.child[0])
+		value = genValue(c0)
 	}
 	tnext := getExec(n.tnext)
 	dest := genValue(n)
 
 	if n.fnext != nil {
 		fnext := getExec(n.fnext)
-		n.exec = func(f *frame) bltn {
-			if value(f).IsNil() {
-				dest(f).SetBool(true)
-				return tnext
+		if c0.typ.cat == interfaceT {
+			n.exec = func(f *frame) bltn {
+				if (value(f).Interface().(valueInterface) == valueInterface{}) {
+					dest(f).SetBool(true)
+					return tnext
+				}
+				dest(f).SetBool(false)
+				return fnext
 			}
-			dest(f).SetBool(false)
-			return fnext
+		} else {
+			n.exec = func(f *frame) bltn {
+				if value(f).IsNil() {
+					dest(f).SetBool(true)
+					return tnext
+				}
+				dest(f).SetBool(false)
+				return fnext
+			}
 		}
 	} else {
-		n.exec = func(f *frame) bltn {
-			dest(f).SetBool(value(f).IsNil())
-			return tnext
+		if c0.typ.cat == interfaceT {
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(value(f).Interface().(valueInterface) == valueInterface{})
+				return tnext
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(value(f).IsNil())
+				return tnext
+			}
 		}
 	}
 }
 
 func isNotNil(n *node) {
 	var value func(*frame) reflect.Value
-	if n.child[0].typ.cat == funcT {
-		value = genValueAsFunctionWrapper(n.child[0])
+	c0 := n.child[0]
+	if c0.typ.cat == funcT {
+		value = genValueAsFunctionWrapper(c0)
 	} else {
-		value = genValue(n.child[0])
+		value = genValue(c0)
 	}
 	tnext := getExec(n.tnext)
 	dest := genValue(n)
 
 	if n.fnext != nil {
 		fnext := getExec(n.fnext)
-		n.exec = func(f *frame) bltn {
-			if value(f).IsNil() {
-				dest(f).SetBool(false)
-				return fnext
+		if c0.typ.cat == interfaceT {
+			n.exec = func(f *frame) bltn {
+				if (value(f).Interface().(valueInterface) == valueInterface{}) {
+					dest(f).SetBool(false)
+					return fnext
+				}
+				dest(f).SetBool(true)
+				return tnext
 			}
-			dest(f).SetBool(true)
-			return tnext
+		} else {
+			n.exec = func(f *frame) bltn {
+				if value(f).IsNil() {
+					dest(f).SetBool(false)
+					return fnext
+				}
+				dest(f).SetBool(true)
+				return tnext
+			}
 		}
 	} else {
-		n.exec = func(f *frame) bltn {
-			dest(f).SetBool(!value(f).IsNil())
-			return tnext
+		if c0.typ.cat == interfaceT {
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(!(value(f).Interface().(valueInterface) == valueInterface{}))
+				return tnext
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(!value(f).IsNil())
+				return tnext
+			}
 		}
 	}
 }


### PR DESCRIPTION
As interpreter interface types are represented using valueInterface
struct, a different comparison routine to nil is required.

Fixes #561.