### PR TITLE
fix: incomplete type analysis

### DIFF
--- a/_test/struct39.go
+++ b/_test/struct39.go
@@ -1,0 +1,22 @@
+package main
+
+type T struct {
+	t *T1
+	y *xxx
+}
+
+type T1 struct {
+	T
+}
+
+var x = &T1{}
+var t = &T{}
+
+type xxx struct{}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/_test/struct40.go
+++ b/_test/struct40.go
@@ -1,0 +1,23 @@
+package main
+
+type T struct {
+	t *T1
+	y *xxx
+}
+
+type T1 struct {
+	T
+}
+
+func f(t *T) { println("in f") }
+
+var x = &T1{}
+
+type xxx struct{}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -63,7 +63,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 					}
 					val = src.rval
 				}
-				if typ.incomplete {
+				if !typ.isComplete() {
 					// Come back when type is known.
 					revisit = append(revisit, n)
 					return false
@@ -94,7 +94,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				if n.typ, err = nodeType(interp, sc, n.child[l]); err != nil {
 					return false
 				}
-				if n.typ.incomplete {
+				if !n.typ.isComplete() {
 					// Come back when type is known.
 					revisit = append(revisit, n)
 					return false
@@ -139,7 +139,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				// Add a function symbol in the package name space
 				sc.sym[n.child[1].ident] = &symbol{kind: funcSym, typ: n.typ, node: n, index: -1}
 			}
-			if n.typ.incomplete {
+			if !n.typ.isComplete() {
 				revisit = append(revisit, n)
 			}
 			return false
@@ -206,7 +206,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				n.typ.method = append(n.typ.method, sc.sym[typeName].typ.method...)
 			}
 			sc.sym[typeName].typ = n.typ
-			if n.typ.incomplete {
+			if !n.typ.isComplete() {
 				revisit = append(revisit, n)
 			}
 			return false


### PR DESCRIPTION
Full analysis of mutually recursive structures requires several
GTA passes and the ability to cancel parsing until type is fully
defined. A recursive type completeness routine is added to better
catch direct or indirect recursive incomplete types.

Fixes #567.