### PR TITLE
fix: better handling of recursive types and forward declarations

### DIFF
--- a/_test/struct41.go
+++ b/_test/struct41.go
@@ -1,0 +1,26 @@
+package main
+
+type Ti func(*T)
+
+type T1 struct {
+	t Ti
+}
+
+type T struct {
+	t Ti
+	y *xxx
+}
+
+func f(t *T) { println("in f") }
+
+type xxx struct{}
+
+var x = &T1{t: f}
+
+func main() {
+	x.t = f
+	println("ok")
+}
+
+// Output:
+// ok

--- a/_test/struct42.go
+++ b/_test/struct42.go
@@ -1,0 +1,19 @@
+package main
+
+type T struct {
+	t func(*T)
+	y *xxx
+}
+
+func f(t *T) { println("in f") }
+
+var x = &T{t: f}
+
+type xxx struct{}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/_test/struct43.go
+++ b/_test/struct43.go
@@ -1,0 +1,19 @@
+package main
+
+type T struct {
+	t func(*T)
+	y *xxx
+}
+
+func f(t *T) { println("in f") }
+
+type xxx struct{}
+
+func main() {
+	x := &T{}
+	x.t = f
+	println("ok")
+}
+
+// Output:
+// ok

--- a/_test/struct44.go
+++ b/_test/struct44.go
@@ -1,0 +1,27 @@
+package main
+
+type Ti func(*T) X
+
+type T1 struct {
+	t Ti
+}
+
+type T struct {
+	t Ti
+	y *xxx
+}
+
+func f(t *T) X { println("in f"); return X{} }
+
+type X struct{ Name string }
+
+type xxx struct{}
+
+var x = &T1{t: f}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -73,7 +73,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 					return false
 				}
 				if typ.isBinMethod {
-					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true}
+					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true, scope: sc}
 				}
 				if sc.sym[dest.ident] == nil {
 					sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
@@ -163,10 +163,10 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 						if isBinType(v) {
 							typ = typ.Elem()
 						}
-						sc.sym[n] = &symbol{kind: binSym, typ: &itype{cat: valueT, rtype: typ}, rval: v}
+						sc.sym[n] = &symbol{kind: binSym, typ: &itype{cat: valueT, rtype: typ, scope: sc}, rval: v}
 					}
 				default: // import symbols in package namespace
-					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath}}
+					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
 				}
 			} else if err = interp.importSrc(rpath, ipath); err == nil {
 				sc.types = interp.universe.types
@@ -179,7 +179,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 						}
 					}
 				default: // import symbols in package namespace
-					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: ipath}}
+					sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: ipath, scope: sc}}
 				}
 			} else {
 				err = n.cfgErrorf("import %q error: %v", ipath, err)
@@ -192,7 +192,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				return false
 			}
 			if n.child[1].kind == identExpr {
-				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, field: typ.field, incomplete: typ.incomplete}
+				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, field: typ.field, incomplete: typ.incomplete, scope: sc}
 				copy(n.typ.method, typ.method)
 			} else {
 				n.typ = typ

--- a/interp/type.go
+++ b/interp/type.go
@@ -278,7 +278,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 					case isFloat64(t0) && isFloat64(t1):
 						t = sc.getType("complex128")
 					case nt0.untyped && isNumber(t0) && nt1.untyped && isNumber(t1):
-						t = &itype{cat: valueT, rtype: complexType}
+						t = &itype{cat: valueT, rtype: complexType, scope: sc}
 					case nt0.untyped && isFloat32(t1) || nt1.untyped && isFloat32(t0):
 						t = sc.getType("complex64")
 					case nt0.untyped && isFloat64(t1) || nt1.untyped && isFloat64(t0):
@@ -301,7 +301,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 					case k == reflect.Complex128:
 						t = sc.getType("float64")
 					case t.untyped && isNumber(t.TypeOf()):
-						t = &itype{cat: valueT, rtype: floatType, untyped: true}
+						t = &itype{cat: valueT, rtype: floatType, untyped: true, scope: sc}
 					default:
 						err = n.cfgErrorf("invalid complex type %s", k)
 					}
@@ -312,7 +312,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				t, err = nodeType(interp, sc, n.child[1])
 			case "new":
 				t, err = nodeType(interp, sc, n.child[1])
-				t = &itype{cat: ptrT, val: t, incomplete: t.incomplete}
+				t = &itype{cat: ptrT, val: t, incomplete: t.incomplete, scope: sc}
 			case "recover":
 				t = sc.getType("interface{}")
 			}
@@ -326,7 +326,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			switch t.cat {
 			case valueT:
 				if t.rtype.NumOut() == 1 {
-					t = &itype{cat: valueT, rtype: t.rtype.Out(0)}
+					t = &itype{cat: valueT, rtype: t.rtype.Out(0), scope: sc}
 				}
 			default:
 				if len(t.ret) == 1 {
@@ -497,11 +497,11 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if m, _ := lt.lookupMethod(name); m != nil {
 				t, err = nodeType(interp, sc, m.child[2])
 			} else if bm, _, _, ok := lt.lookupBinMethod(name); ok {
-				t = &itype{cat: valueT, rtype: bm.Type, isBinMethod: true}
+				t = &itype{cat: valueT, rtype: bm.Type, isBinMethod: true, scope: sc}
 			} else if ti := lt.lookupField(name); len(ti) > 0 {
 				t = lt.fieldSeq(ti)
 			} else if bs, _, ok := lt.lookupBinField(name); ok {
-				t = &itype{cat: valueT, rtype: bs.Type}
+				t = &itype{cat: valueT, rtype: bs.Type, scope: sc}
 			} else {
 				err = lt.node.cfgErrorf("undefined selector %s", name)
 			}
@@ -941,24 +941,40 @@ func exportName(s string) string {
 var interf = reflect.TypeOf(new(interface{})).Elem()
 
 func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.Type {
-	if t.rtype != nil {
-		if wrapRecursive && t.cat == structT && defined[t.name] != nil {
-			return interf
-		}
-		return t.rtype
-	}
-
 	if t.incomplete || t.cat == nilT {
 		var err error
 		if t, err = t.finalize(); err != nil {
 			panic(err)
 		}
 	}
-	if t.val != nil && defined[t.val.name] != nil && !t.val.incomplete && t.val.rtype == nil {
+	// Predefined types from universe of runtime may have a nil scope.
+	if t.scope != nil {
+		if st := t.scope.sym[t.name]; st != nil {
+			// Update the type recursive status. Several copies of type
+			// may exist per symbol, as a new type is created at each GTA
+			// pass (several needed due to out of order declarations), and
+			// a node can still point to a previous copy.
+			t.recursive = t.recursive || st.typ.recursive
+			st.typ.recursive = t.recursive
+		}
+	}
+	if wrapRecursive && t.recursive {
+		return interf
+	}
+	if t.rtype != nil {
+		return t.rtype
+	}
+	if defined[t.name] != nil && defined[t.name].rtype != nil {
+		return defined[t.name].rtype
+	}
+	if t.val != nil && defined[t.val.name] != nil && t.val.rtype == nil {
 		// Replace reference to self (direct or indirect) by an interface{} to handle
 		// recursive types with reflect.
 		t.val.rtype = interf
+		t.recursive = true
 		defined[t.val.name].recursive = true
+		// A previous type definition attempt may be still in use.
+		t.scope.sym[t.val.name].typ.recursive = true
 	}
 	switch t.cat {
 	case aliasT:
@@ -974,9 +990,11 @@ func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.T
 	case errorT:
 		t.rtype = reflect.TypeOf(new(error)).Elem()
 	case funcT:
+		if t.name != "" {
+			defined[t.name] = t
+		}
 		in := make([]reflect.Type, len(t.arg))
 		out := make([]reflect.Type, len(t.ret))
-		//wrap := false
 		for i, v := range t.arg {
 			in[i] = v.refType(defined, true)
 		}
@@ -992,6 +1010,10 @@ func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.T
 		t.rtype = reflect.PtrTo(t.val.refType(defined, wrapRecursive))
 	case structT:
 		if t.name != "" {
+			if defined[t.name] != nil {
+				t.recursive = true
+				t.scope.sym[t.name].typ.recursive = true
+			}
 			defined[t.name] = t
 		}
 		var fields []reflect.StructField

--- a/interp/type.go
+++ b/interp/type.go
@@ -947,7 +947,7 @@ func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.T
 			panic(err)
 		}
 	}
-	// Predefined types from universe of runtime may have a nil scope.
+	// Predefined types from universe or runtime may have a nil scope.
 	if t.scope != nil {
 		if st := t.scope.sym[t.name]; st != nil {
 			// Update the type recursive status. Several copies of type


### PR DESCRIPTION
As several GTA passes are required to handle forward declarations
and recursive types, make sure to update the type recursive status
in the type symbol, using scope to retrieve the symbol. The scope
was not always recorded at type creation. Fix that for dynamic
type creation which are potentially recursive.

Update refType() to return and interface{} in place of struct to
represent a recursive type using reflect.

Fixes #570.