### PR TITLE
fix: lookup embededded field on struct pointer

### DIFF
--- a/_test/struct45.go
+++ b/_test/struct45.go
@@ -1,0 +1,17 @@
+package main
+
+type T struct {
+	b bool
+}
+
+type T1 struct {
+	T
+}
+
+func main() {
+	t := &T1{}
+	t.b = true
+	println(t.b)
+}
+
+// Output: true

--- a/interp/type.go
+++ b/interp/type.go
@@ -857,7 +857,8 @@ func (t *itype) zero() (v reflect.Value, err error) {
 
 // fieldIndex returns the field index from name in a struct, or -1 if not found
 func (t *itype) fieldIndex(name string) int {
-	if t.cat == ptrT {
+	switch t.cat {
+	case aliasT, ptrT:
 		return t.val.fieldIndex(name)
 	}
 	for i, field := range t.field {
@@ -882,6 +883,10 @@ func (t *itype) fieldSeq(seq []int) *itype {
 
 // lookupField returns a list of indices, i.e. a path to access a field in a struct object
 func (t *itype) lookupField(name string) []int {
+	switch t.cat {
+	case aliasT, ptrT:
+		return t.val.lookupField(name)
+	}
 	if fi := t.fieldIndex(name); fi >= 0 {
 		return []int{fi}
 	}


### PR DESCRIPTION
On a struct pointer, it is necessary to dereference the struct
before iterating on its fields.

Fixes #575.