### PR TITLE
fix: correct control flow graph for select blocks

### DIFF
--- a/_test/chan9.go
+++ b/_test/chan9.go
@@ -1,0 +1,20 @@
+package main
+
+type Channel chan string
+
+type T struct {
+	Channel
+}
+
+func send(c Channel) { c <- "ping" }
+
+func main() {
+	t := &T{}
+	t.Channel = make(Channel)
+	go send(t.Channel)
+	msg := <-t.Channel
+	println(msg)
+}
+
+// Output:
+// ping

--- a/_test/select4.go
+++ b/_test/select4.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	c1 := make(chan string)
+
+	go func() { c1 <- "done" }()
+
+	select {
+	case msg1 := <-c1:
+		println("received from c1:", msg1)
+	}
+	println("Bye")
+}
+
+// Output:
+// received from c1: done
+// Bye

--- a/_test/select5.go
+++ b/_test/select5.go
@@ -1,0 +1,23 @@
+package main
+
+type T struct {
+	c1 chan string
+}
+
+func main() {
+	t := &T{}
+	t.c1 = make(chan string)
+
+	go func(c chan string) { c <- "done"; println("sent") }(t.c1)
+
+	select {
+	case msg1 := <-t.c1:
+		println("received from c1:", msg1)
+	}
+	println("Bye")
+}
+
+// Output:
+// sent
+// received from c1: done
+// Bye

--- a/_test/select6.go
+++ b/_test/select6.go
@@ -11,12 +11,12 @@ func main() {
 	go func(c chan string) { c <- "done" }(t.c1)
 
 	select {
-	case msg1 := <-t.c1:
-		println("received from c1:", msg1)
+	case <-t.c1:
+		println("received from c1")
 	}
 	println("Bye")
 }
 
 // Output:
-// received from c1: done
+// received from c1
 // Bye

--- a/_test/select7.go
+++ b/_test/select7.go
@@ -17,8 +17,8 @@ func main() {
 	}()
 
 	msg1 := <-t.c1
-	println("received from c1:", msg1, a)
+	println("received from c1:", msg1)
 }
 
 // Output:
-// received from c1: done 1
+// received from c1: done

--- a/_test/select7.go
+++ b/_test/select7.go
@@ -1,0 +1,24 @@
+package main
+
+type T struct {
+	c1 chan string
+}
+
+func main() {
+	t := &T{}
+	t.c1 = make(chan string)
+	a := 0
+
+	go func() {
+		select {
+		case t.c1 <- "done":
+			a++
+		}
+	}()
+
+	msg1 := <-t.c1
+	println("received from c1:", msg1, a)
+}
+
+// Output:
+// received from c1: done 1

--- a/_test/select8.go
+++ b/_test/select8.go
@@ -1,0 +1,24 @@
+package main
+
+type T struct {
+	c1 chan string
+	c2 chan string
+}
+
+func main() {
+	t := &T{}
+	t.c1 = make(chan string)
+
+	go func(c chan string) { c <- "done" }(t.c1)
+
+	select {
+	case msg := <-t.c1:
+		println("received from c1:", msg)
+	case <-t.c2:
+	}
+	println("Bye")
+}
+
+// Output:
+// received from c1: done
+// Bye

--- a/_test/select9.go
+++ b/_test/select9.go
@@ -1,0 +1,22 @@
+package main
+
+type T struct {
+	c1 chan string
+}
+
+func main() {
+	t := &T{}
+	t.c1 = make(chan string)
+
+	go func() {
+		select {
+		case t.c1 <- "done":
+		}
+	}()
+
+	msg1 := <-t.c1
+	println("received from c1:", msg1)
+}
+
+// Output:
+// received from c1: done

--- a/interp/type.go
+++ b/interp/type.go
@@ -1157,6 +1157,24 @@ func isShiftNode(n *node) bool {
 	return false
 }
 
+// chanElement returns the channel element type.
+func chanElement(t *itype) *itype {
+	switch t.cat {
+	case aliasT:
+		return chanElement(t.val)
+	case chanT:
+		return t.val
+	case valueT:
+		return &itype{cat: valueT, rtype: t.rtype.Elem(), node: t.node, scope: t.scope}
+	}
+	return nil
+}
+
+// isChan returns true if type is of channel kind.
+func isChan(t *itype) bool {
+	return t.TypeOf().Kind() == reflect.Chan
+}
+
 func isInterfaceSrc(t *itype) bool {
 	return t.cat == interfaceT || (t.cat == aliasT && isInterfaceSrc(t.val))
 }


### PR DESCRIPTION
Receive channel in comm clause of select statements were only supported
for channel variables. Now channel init actions, for example to access
a channel struct field, are properly chained prior to invoke the select
operation. In addition, verify that the receive operation is on a
channel type data.

Fixes #577.