### PR TITLE
fix: assign composite literal by reference

### DIFF
--- a/_test/composite8.go
+++ b/_test/composite8.go
@@ -1,0 +1,16 @@
+package main
+
+type T struct{ I int }
+
+func main() {
+	t := []*T{}
+	s := []int{1, 2}
+	for _, e := range s {
+		x := &T{e}
+		t = append(t, x)
+	}
+	println(t[0].I, t[1].I)
+}
+
+// Output:
+// 1 2

--- a/interp/run.go
+++ b/interp/run.go
@@ -1732,6 +1732,7 @@ func doCompositeLit(n *node, hasType bool) {
 		}
 	}
 
+	i := n.findex
 	n.exec = func(f *frame) bltn {
 		a := reflect.New(n.typ.TypeOf()).Elem()
 		for i, v := range values {
@@ -1743,7 +1744,7 @@ func doCompositeLit(n *node, hasType bool) {
 		case destInterface:
 			d.Set(reflect.ValueOf(valueInterface{n, a}))
 		default:
-			d.Set(a)
+			f.data[i] = a
 		}
 		return next
 	}


### PR DESCRIPTION
When using reflect.Set() to assign a struct object to a variable, all
data is duplicated, but the underlying struct address in destination is
not affected, which is different of allocating a new struct.  The right
behaviour is to set directly the reflect.Value in the frame, without
using Set.

Fixes #579.