### PR TITLE
fix: correct handling of interface types in composite literals

### DIFF
--- a/_test/interface31.go
+++ b/_test/interface31.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := []interface{}{"test", 2}
+	fmt.Println(s[0], s[1])
+}
+
+// Output:
+// test 2

--- a/_test/interface32.go
+++ b/_test/interface32.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := [2]interface{}{"test", 2}
+	fmt.Println(s[0], s[1])
+}
+
+// Output:
+// test 2

--- a/_test/interface33.go
+++ b/_test/interface33.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a = map[string]interface{}{"test": "test"}
+	fmt.Println(a["test"])
+}
+
+// Output:
+// test

--- a/_test/interface34.go
+++ b/_test/interface34.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := [2]interface{}{1: "test", 0: 2}
+	fmt.Println(s[0], s[1])
+}
+
+// Output:
+// 2 test

--- a/_test/interface35.go
+++ b/_test/interface35.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+type T struct {
+	I interface{}
+}
+
+func main() {
+	t := T{"test"}
+	fmt.Println(t)
+}
+
+// Output:
+// test

--- a/_test/interface35.go
+++ b/_test/interface35.go
@@ -12,4 +12,4 @@ func main() {
 }
 
 // Output:
-// test
+// {test}

--- a/interp/type.go
+++ b/interp/type.go
@@ -844,7 +844,7 @@ func (t *itype) zero() (v reflect.Value, err error) {
 		v, err = t.val.zero()
 
 	case arrayT, ptrT, structT:
-		v = reflect.New(t.TypeOf()).Elem()
+		v = reflect.New(t.frameType()).Elem()
 
 	case valueT:
 		v = reflect.New(t.rtype).Elem()
@@ -1002,7 +1002,7 @@ func exportName(s string) string {
 	return "X" + s
 }
 
-var interf = reflect.TypeOf(new(interface{})).Elem()
+var interf = reflect.TypeOf((*interface{})(nil)).Elem()
 
 // RefType returns a reflect.Type representation from an interpereter type.
 // In simple cases, reflect types are directly mapped from the interpreter


### PR DESCRIPTION
Interface values must be wrapped in valueInterface struct. This was
missing for composite literals. Also make sure to use frameType
method instead of TypeOf to get the correct reflect.Type representation.

Fixes #581.