### PR TITLE
fix: correct branch control flow graph for parenthesis expressions

### DIFF
--- a/_test/not0.go
+++ b/_test/not0.go
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+        a := 0
+        b := true
+	c := false
+        if (b && c) {
+                a = 1
+        } else {
+                a = -1
+        }
+        println(a)
+}
+
+// Output:
+// -1

--- a/_test/not1.go
+++ b/_test/not1.go
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+        a := 0
+        b := true
+        if (!b) {
+                a = 1
+        } else {
+                a = -1
+        }
+        println(a)
+}
+
+// Output:
+// -1

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -196,6 +196,7 @@ const (
 	aAndNot
 	aAndNotAssign
 	aBitNot
+	aBranch
 	aCall
 	aCase
 	aCompositeLit
@@ -253,6 +254,7 @@ var actions = [...]string{
 	aAndNot:       "&^",
 	aAndNotAssign: "&^=",
 	aBitNot:       "^",
+	aBranch:       "branch",
 	aCall:         "call",
 	aCase:         "case",
 	aCompositeLit: "compositeLit",


### PR DESCRIPTION
The branch condition was not always set or propagated in presence
of parenthesis expressions. Add a setFNext function to fix that.

Fixes #571.