### PR TITLE
fix: do not convert literal float to int at parse

### DIFF
--- a/_test/num0.go
+++ b/_test/num0.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("%g\n", 1.0)
+}
+
+// Output:
+// 1

--- a/_test/op4.go
+++ b/_test/op4.go
@@ -1,9 +1,9 @@
 package main
 
 func main() {
-	i := 100
-	println(i % 1e2)
+	i := 102
+	println(i % -1e2)
 }
 
 // Output:
-// 0
+// 2

--- a/_test/op5.go
+++ b/_test/op5.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	i := 100
+	j := i % 1e2
+	fmt.Printf("%T %v\n", j, j)
+}
+
+// Output:
+// int 0

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
-	"math"
 	"reflect"
 	"strconv"
 	"sync/atomic"
@@ -466,11 +465,7 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 				n.rval = reflect.ValueOf(v)
 			case token.FLOAT:
 				v, _ := strconv.ParseFloat(a.Value, 64)
-				if math.Trunc(v) == v {
-					n.rval = reflect.ValueOf(int(v))
-				} else {
-					n.rval = reflect.ValueOf(v)
-				}
+				n.rval = reflect.ValueOf(v)
 			case token.IMAG:
 				v, _ := strconv.ParseFloat(a.Value[:len(a.Value)-1], 64)
 				n.rval = reflect.ValueOf(complex(0, v))

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -590,10 +590,15 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				if !(isNumber(t0) && isNumber(t1)) {
 					err = n.cfgErrorf("illegal operand types for '%v' operator", n.action)
 				}
-			case aRem, aAnd, aOr, aXor, aAndNot:
+			case aAnd, aOr, aXor, aAndNot:
 				if !(isInt(t0) && isInt(t1)) {
 					err = n.cfgErrorf("illegal operand types for '%v' operator", n.action)
 				}
+			case aRem:
+				if !(c0.isInteger() && c1.isInteger()) {
+					err = n.cfgErrorf("illegal operand types for '%v' operator", n.action)
+				}
+				n.typ = c0.typ
 			case aShl, aShr:
 				if !(c0.isInteger() && c1.isNatural()) {
 					err = n.cfgErrorf("illegal operand types for '%v' operator", n.action)


### PR DESCRIPTION
The conversion should occur only for certain arithmetic operators.
Also fixes the remain operator type checks.

Fixes #568.