### PR TITLE
fix: handle forward declaration for aliased type

### DIFF
--- a/_test/type22.go
+++ b/_test/type22.go
@@ -1,0 +1,15 @@
+package main
+
+type T1 T
+
+func foo() T1 {
+	return T1(T{"foo"})
+}
+
+type T struct {
+	Name string
+}
+
+func main() {
+	println(foo().Name)
+}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -192,7 +192,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				return false
 			}
 			if n.child[1].kind == identExpr {
-				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, field: typ.field, incomplete: typ.incomplete, scope: sc}
+				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, field: typ.field, incomplete: typ.incomplete, scope: sc, node: n.child[0]}
 				copy(n.typ.method, typ.method)
 			} else {
 				n.typ = typ


### PR DESCRIPTION
Populate the node field in the alias type creation so type can be
parsed again later when dependency is complete.

Fixes #592.