### PR TITLE
fix: handle type conversion from pre-compiled types.

### DIFF
--- a/_test/time12.go
+++ b/_test/time12.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+var twentyFourHours = time.Duration(24 * time.Hour)
+
+func main() {
+	fmt.Println(twentyFourHours.Hours())
+}
+
+// Output:
+// 24

--- a/interp/type.go
+++ b/interp/type.go
@@ -325,8 +325,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			}
 			switch t.cat {
 			case valueT:
-				if t.rtype.NumOut() == 1 {
-					t = &itype{cat: valueT, rtype: t.rtype.Out(0), scope: sc}
+				if rt := t.rtype; rt.Kind() == reflect.Func && rt.NumOut() == 1 {
+					t = &itype{cat: valueT, rtype: rt.Out(0), scope: sc}
 				}
 			default:
 				if len(t.ret) == 1 {


### PR DESCRIPTION
Do not attempt to get the number of return args if the value
does not refer to a function, but a type.

Fixes #597.