### PR TITLE
fix: handle default comm clause in select

### DIFF
--- a/_test/select10.go
+++ b/_test/select10.go
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	c := make(chan string)
+	select {
+	case <-c:
+		println("unexpected")
+	default:
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/select11.go
+++ b/_test/select11.go
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+	c := make(chan string)
+	select {
+	case <-c:
+		println("unexpected")
+	default:
+		println("nothing received")
+	}
+	println("bye")
+}
+
+// Output:
+// nothing received
+// bye


### PR DESCRIPTION
The default comm clause, allowing to unblock select, was not correctly
implemented.

Fixes #599.