### PR TITLE
fix: improve handling of function return values

### DIFF
--- a/_test/append0.go
+++ b/_test/append0.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func f(a []int, b int) interface{} { return append(a, b) }
+
+func main() {
+	a := []int{1, 2}
+	r := f(a, 3)
+	fmt.Println(r.([]int))
+}
+
+// Output:
+// [1 2 3]

--- a/_test/cap0.go
+++ b/_test/cap0.go
@@ -1,0 +1,13 @@
+package main
+
+func f(a []int) interface{} {
+	return cap(a)
+}
+
+func main() {
+	a := []int{1, 2}
+	println(f(a).(int))
+}
+
+// Output:
+// 2

--- a/_test/complex4.go
+++ b/_test/complex4.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func f(a, b float64) interface{} { return complex(a, b) }
+
+func main() {
+	a := f(3, 2)
+	fmt.Println(a.(complex128))
+}
+
+// Output:
+// (3+2i)

--- a/_test/copy2.go
+++ b/_test/copy2.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func f(a, b []int) interface{} { return copy(a, b) }
+
+func main() {
+	a := []int{10, 20, 30}
+	b := [4]int{}
+	c := b[:]
+	r := f(c, a)
+	fmt.Println(r.(int))
+}
+
+// Output:
+// 3

--- a/_test/fun14.go
+++ b/_test/fun14.go
@@ -1,0 +1,13 @@
+package main
+
+func f() (bool, int) { return true, 2 }
+
+func g() (bool, int) { return f() }
+
+func main() {
+	b, i := g()
+	println(b, i)
+}
+
+// Output
+// true 2

--- a/_test/imag0.go
+++ b/_test/imag0.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func f(c complex128) interface{} { return imag(c) }
+
+func main() {
+	c := complex(3, 2)
+	a := f(c)
+	fmt.Println(a.(float64))
+}
+
+// Output:
+// 2

--- a/_test/len0.go
+++ b/_test/len0.go
@@ -1,0 +1,13 @@
+package main
+
+func f(a []int) interface{} {
+	return len(a)
+}
+
+func main() {
+	a := []int{1, 2}
+	println(f(a).(int))
+}
+
+// Output:
+// 2

--- a/_test/make0.go
+++ b/_test/make0.go
@@ -1,0 +1,13 @@
+package main
+
+func f() interface{} {
+	return make([]int, 2)
+}
+
+func main() {
+	a := f()
+	println(len(a.([]int)))
+}
+
+// Output:
+// 2

--- a/_test/make1.go
+++ b/_test/make1.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func f() interface{} {
+	return make(map[int]int)
+}
+
+func main() {
+	a, ok := f().(map[int]int)
+	fmt.Println(a, ok)
+}
+
+// Output:
+// map[] true

--- a/_test/new2.go
+++ b/_test/new2.go
@@ -1,0 +1,10 @@
+package main
+
+func f() interface{} {
+	return new(int)
+}
+
+func main() {
+	a := f()
+	println(*(a.(*int)))
+}

--- a/_test/real0.go
+++ b/_test/real0.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func f(c complex128) interface{} { return real(c) }
+
+func main() {
+	c := complex(3, 2)
+	a := f(c)
+	fmt.Println(a.(float64))
+}
+
+// Output:
+// 3

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -199,6 +199,7 @@ const (
 	aCall
 	aCase
 	aCompositeLit
+	aConvert
 	aDec
 	aEqual
 	aGreater
@@ -257,6 +258,7 @@ var actions = [...]string{
 	aCall:         "call",
 	aCase:         "case",
 	aCompositeLit: "compositeLit",
+	aConvert:      "convert",
 	aDec:          "--",
 	aEqual:        "==",
 	aGreater:      ">",

--- a/interp/value.go
+++ b/interp/value.go
@@ -182,6 +182,21 @@ func zeroInterfaceValue() reflect.Value {
 	return reflect.ValueOf(valueInterface{n, v})
 }
 
+func genValueOutput(n *node, t reflect.Type) func(*frame) reflect.Value {
+	value := genValue(n)
+	if n.anc.kind == returnStmt && n.anc.val.(*node).typ.ret[0].cat == interfaceT {
+		// The result of the builtin has to be returned as an interface type.
+		// Wrap it in a valueInterface and return the dereferenced value.
+		return func(f *frame) reflect.Value {
+			d := value(f)
+			v := reflect.New(t).Elem()
+			d.Set(reflect.ValueOf(valueInterface{n, v}))
+			return v
+		}
+	}
+	return value
+}
+
 func genValueInterfaceValue(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 


### PR DESCRIPTION
Avoid duplication of func call output in frame, when function is
called from a return statement.

Handle the conversion of func outputs to interface if necessary,
with more changes to come.

Improve internal code comments.

Improve test coverage.

Fixes #607