### PR TITLE
fix: improve generation of interface wrapper

### DIFF
--- a/_test/bin5.go
+++ b/_test/bin5.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func main() {
+	addr := net.TCPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 80}
+	var s fmt.Stringer = &addr
+	fmt.Println(s.String())
+}
+
+// Output:
+// 1.1.1.1:80

--- a/_test/fun14.go
+++ b/_test/fun14.go
@@ -9,5 +9,5 @@ func main() {
 	println(b, i)
 }
 
-// Output
+// Output:
 // true 2

--- a/_test/new2.go
+++ b/_test/new2.go
@@ -8,3 +8,6 @@ func main() {
 	a := f()
 	println(*(a.(*int)))
 }
+
+// Output:
+// 0

--- a/_test/struct37.go
+++ b/_test/struct37.go
@@ -15,3 +15,6 @@ func main() {
 	_, err := c.Get("url")
 	println(strings.Contains(err.Error(), "unsupported protocol scheme"))
 }
+
+// Output:
+// true

--- a/_test/struct45.go
+++ b/_test/struct45.go
@@ -14,4 +14,5 @@ func main() {
 	println(t.b)
 }
 
-// Output: true
+// Output:
+// true

--- a/_test/type22.go
+++ b/_test/type22.go
@@ -13,3 +13,6 @@ type T struct {
 func main() {
 	println(foo().Name)
 }
+
+// Output:
+// foo

--- a/interp/run.go
+++ b/interp/run.go
@@ -594,9 +594,13 @@ func genInterfaceWrapper(n *node, typ reflect.Type) func(*frame) reflect.Value {
 		w := reflect.New(wrap).Elem()
 		for i, m := range methods {
 			if m == nil {
+				if r := v.MethodByName(names[i]); r.IsValid() {
+					w.Field(i).Set(r)
+					continue
+				}
 				o := vv.FieldByIndex(indexes[i])
 				if r := o.MethodByName(names[i]); r.IsValid() {
-					w.Field(i).Set(o.MethodByName(names[i]))
+					w.Field(i).Set(r)
 				} else {
 					log.Println(n.cfgErrorf("genInterfaceWrapper error, no method %s", names[i]))
 				}


### PR DESCRIPTION
The method resolution can also be attempted directly on the
passed value.

While here, fix some expected test outputs.

Fixes #609.