### PR TITLE
feature: pre-import used packages in REPL mode.

### DIFF
--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -11,7 +11,7 @@ a terminal.
 File Mode
 
 In file mode, as in a standard Go compiler, source files are read entirely
-before being fully parsed, then evaluated. It allows to handle forward
+before being parsed, then evaluated. It allows to handle forward
 declarations and to have package code split in multiple source files.
 
 Go specifications fully apply in this mode.
@@ -30,18 +30,17 @@ suitable for interactive command line and scripts.
 Go specifications apply with the following differences:
 
 All local and global declarations (const, var, type, func) are allowed,
-except that forward declarations are forbidden (as declarations inside
-a standard Go function), and import statement can be interleaved with
-other instructions.
+including in short form, except that all identifiers must be defined
+before use (as declarations inside a standard Go function).
 
 The statements are evaluated in the global space, within an implicit
 "main" package.
 
 It is not necessary to have a package statement, or a main function in
-REPL mode.  Import statements for preloaded binary packages can also
+REPL mode. Import statements for preloaded binary packages can also
 be avoided (i.e. all the standard library except the few packages
 where default names collide, as "math/rand" and "crypto/rand", for which
-explicit import is still necessary).
+an explicit import is still necessary).
 
 Note that the source packages are always interpreted in file mode,
 even if imported from REPL.

--- a/cmd/yaegi/yaegi_test.go
+++ b/cmd/yaegi/yaegi_test.go
@@ -84,7 +84,7 @@ func TestYaegiCmdCancel(t *testing.T) {
 			continue
 		}
 
-		if outBuf.String() != "context canceled\n2\n" {
+		if outBuf.String() != "context canceled\n" {
 			t.Errorf("unexpected output: %q", &outBuf)
 		}
 	}


### PR DESCRIPTION
In REPL mode, pre-import all used pre-compiled binary packages,
except those having default name collisions (`crypto/rand`, `math/rand`).

Also enable REPL mode for yaegi script files (starting with `#!`).

Improve the yaegi doc to clarify differences between file mode and
REPL mode.

This change allows the following code to be a valid executable script:

```
#!/usr/bin/env yaegi
helloHandler := func(w http.ResponseWriter, req *http.Request) {
   io.WriteString(w, "Hello, world!\n")
}
http.HandleFunc("/hello", helloHandler)
log.Fatal(http.ListenAndServe(":8080", nil))
```

Or to execute a one-liner such as:

```
$ yaegi -e 'println(reflect.TypeOf(fmt.Printf))'
```

This change has no impact on the default file mode (pure Go files),
or on the interp library.