### PR TITLE
fix: correct assign from function returning an interface value

### DIFF
--- a/_test/interface37.go
+++ b/_test/interface37.go
@@ -1,0 +1,23 @@
+package main
+
+type I interface {
+	A() string
+	B() string
+}
+
+type s struct{}
+
+func NewS() (I, error) {
+	return &s{}, nil
+}
+
+func (c *s) A() string { return "a" }
+func (c *s) B() string { return "b" }
+
+func main() {
+	s, _ := NewS()
+	println(s.A())
+}
+
+// Output:
+// a

--- a/interp/run.go
+++ b/interp/run.go
@@ -678,7 +678,7 @@ func call(n *node) {
 			switch {
 			case c.ident == "_":
 				// Skip assigning return value to blank var.
-			case c.typ.cat == interfaceT:
+			case c.typ.cat == interfaceT && rtypes[i].cat != interfaceT:
 				rvalues[i] = genValueInterfaceValue(c)
 			default:
 				rvalues[i] = genValue(c)


### PR DESCRIPTION
The wrapping of result in valueInterface is necessary only if
the source type is not already an interfaceT.

Fixes #623