### PR TITLE
fix: assign an element in a map from runtime

### DIFF
--- a/_test/map27.go
+++ b/_test/map27.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"text/template"
+)
+
+type fm map[string]interface{}
+
+type foo struct{}
+
+func main() {
+	a := make(fm)
+	a["foo"] = &foo{}
+	fmt.Println(a["foo"])
+
+	b := make(template.FuncMap) // type FuncMap map[string]interface{}
+	b["foo"] = &foo{}
+	fmt.Println(b["foo"])
+}
+
+// Output:
+// &{}
+// &{}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1978,7 +1978,7 @@ func isMethod(n *node) bool {
 }
 
 func isMapEntry(n *node) bool {
-	return n.action == aGetIndex && n.child[0].typ.cat == mapT
+	return n.action == aGetIndex && isMap(n.child[0].typ)
 }
 
 func isBinCall(n *node) bool {

--- a/interp/type.go
+++ b/interp/type.go
@@ -1222,10 +1222,9 @@ func chanElement(t *itype) *itype {
 	return nil
 }
 
-// isChan returns true if type is of channel kind.
-func isChan(t *itype) bool {
-	return t.TypeOf().Kind() == reflect.Chan
-}
+func isBool(t *itype) bool { return t.TypeOf().Kind() == reflect.Bool }
+func isChan(t *itype) bool { return t.TypeOf().Kind() == reflect.Chan }
+func isMap(t *itype) bool  { return t.TypeOf().Kind() == reflect.Map }
 
 func isInterfaceSrc(t *itype) bool {
 	return t.cat == interfaceT || (t.cat == aliasT && isInterfaceSrc(t.val))
@@ -1250,8 +1249,6 @@ func isStruct(t *itype) bool {
 		return false
 	}
 }
-
-func isBool(t *itype) bool { return t.TypeOf().Kind() == reflect.Bool }
 
 func isInt(t reflect.Type) bool {
 	if t == nil {


### PR DESCRIPTION
The map entry detection routine was skipping map created in
runtime.

Fixes #624.