### PR TITLE
fix: handle empty clause in switch if statement

### DIFF
--- a/_test/switch35.go
+++ b/_test/switch35.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	a := 2
+	switch {
+	case a == 1:
+		println(1)
+	case a == 2:
+		println(2)
+	default:
+	}
+	println("bye")
+}
+
+// Output:
+// 2
+// bye

--- a/_test/switch36.go
+++ b/_test/switch36.go
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	a := 2
+	switch {
+	case a == 1:
+		println(1)
+	case a == 2:
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/_test/switch37.go
+++ b/_test/switch37.go
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	a := 2
+	switch {
+	case a == 1:
+		println(1)
+	case a == 3:
+	default:
+	}
+	println("bye")
+}
+
+// Output:
+// bye

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1510,24 +1510,29 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			for i := l - 1; i >= 0; i-- {
 				c := clauses[i]
 				c.gen = nop
-				body := c.lastChild()
-				if len(c.child) > 1 {
-					cond := c.child[0]
-					cond.tnext = body.start
-					if i == l-1 {
-						setFNext(cond, n)
+				if len(c.child) == 0 {
+					c.tnext = n
+					c.fnext = n
+				} else {
+					body := c.lastChild()
+					if len(c.child) > 1 {
+						cond := c.child[0]
+						cond.tnext = body.start
+						if i == l-1 {
+							setFNext(cond, n)
+						} else {
+							setFNext(cond, clauses[i+1].start)
+						}
+						c.start = cond.start
 					} else {
-						setFNext(cond, clauses[i+1].start)
+						c.start = body.start
 					}
-					c.start = cond.start
-				} else {
-					c.start = body.start
-				}
-				// If last case body statement is a fallthrough, then jump to next case body
-				if i < l-1 && len(body.child) > 0 && body.lastChild().kind == fallthroughtStmt {
-					body.tnext = clauses[i+1].lastChild().start
-				} else {
-					body.tnext = n
+					// If last case body statement is a fallthrough, then jump to next case body
+					if i < l-1 && len(body.child) > 0 && body.lastChild().kind == fallthroughtStmt {
+						body.tnext = clauses[i+1].lastChild().start
+					} else {
+						body.tnext = n
+					}
 				}
 			}
 			sbn.start = clauses[0].start


### PR DESCRIPTION
The CFG was wrong in presence of an empty last clause.

Fixes #634.