### PR TITLE
fix: use interface wrappers to expose interface values to runtime

### DIFF
--- a/_test/interface38.go
+++ b/_test/interface38.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type foo struct {
+	bar string
+}
+
+func (f foo) String() string {
+	return "Hello from " + f.bar
+}
+
+func main() {
+	var f fmt.Stringer = foo{bar: "bar"}
+	fmt.Println(f)
+}
+
+// Output:
+// Hello from bar

--- a/_test/interface39.go
+++ b/_test/interface39.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type foo struct {
+	bar string
+}
+
+func (f *foo) String() string {
+	return "Hello from " + f.bar
+}
+
+func main() {
+	var f fmt.Stringer = &foo{bar: "bar"}
+	fmt.Println(f)
+}
+
+// Output:
+// Hello from bar

--- a/_test/interface40.go
+++ b/_test/interface40.go
@@ -10,12 +10,12 @@ func (f foo) String() string {
 	return "Hello from " + f.bar
 }
 
-func NewFoo(s string) fmt.Stringer {
+func Foo(s string) fmt.Stringer {
 	return foo{s}
 }
 
 func main() {
-	f := NewFoo("bar")
+	f := Foo("bar")
 	fmt.Println(f)
 }
 

--- a/_test/interface40.go
+++ b/_test/interface40.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+type foo struct {
+	bar string
+}
+
+func (f foo) String() string {
+	return "Hello from " + f.bar
+}
+
+func NewFoo(s string) fmt.Stringer {
+	return foo{s}
+}
+
+func main() {
+	f := NewFoo("bar")
+	fmt.Println(f)
+}
+
+// Output:
+// Hello from bar

--- a/_test/interface41.go
+++ b/_test/interface41.go
@@ -10,12 +10,12 @@ func (f *foo) String() string {
 	return "Hello from " + f.bar
 }
 
-func NewFoo(s string) fmt.Stringer {
+func Foo(s string) fmt.Stringer {
 	return &foo{s}
 }
 
 func main() {
-	f := NewFoo("bar")
+	f := Foo("bar")
 	fmt.Println(f)
 }
 

--- a/_test/interface41.go
+++ b/_test/interface41.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+type foo struct {
+	bar string
+}
+
+func (f *foo) String() string {
+	return "Hello from " + f.bar
+}
+
+func NewFoo(s string) fmt.Stringer {
+	return &foo{s}
+}
+
+func main() {
+	f := NewFoo("bar")
+	fmt.Println(f)
+}
+
+// Output:
+// Hello from bar

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -507,13 +507,15 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					src.findex = dest.findex // Set recv address to LHS
 					dest.typ = src.typ
 				case n.action == aAssign && src.action == aCompositeLit:
-					if !(dest.typ.cat == valueT && dest.typ.rtype.Kind() == reflect.Interface) {
-						// Output literal composite to destination (avoiding assign operation)
-						// only if there is no need to wrap to an interface.
-						n.gen = nop
-						src.findex = dest.findex
-						src.level = level
+					if dest.typ.cat == valueT && dest.typ.rtype.Kind() == reflect.Interface {
+						// No optimisation attempt for assigned binary interface
+						break
 					}
+					// Skip the assign operation entirely, the source frame index is set
+					// to destination index, avoiding extra memory alloc and duplication.
+					n.gen = nop
+					src.findex = dest.findex
+					src.level = level
 				case src.kind == basicLit:
 					// TODO: perform constant folding and propagation here.
 					switch {

--- a/interp/run.go
+++ b/interp/run.go
@@ -1595,6 +1595,12 @@ func _return(n *node) {
 			values[i] = genValue(c)
 		case interfaceT:
 			values[i] = genValueInterface(c)
+		case valueT:
+			if t.rtype.Kind() == reflect.Interface {
+				values[i] = genInterfaceWrapper(c, t.rtype)
+				break
+			}
+			fallthrough
 		default:
 			if c.typ.untyped {
 				values[i] = genValueAs(c, def.typ.ret[i].TypeOf())


### PR DESCRIPTION
If a value is assigned to, or returned as, a binary interface,
then use the interface wrapper generator to convert the value
accordingly.

Fixes #630.