### PR TITLE
fix: correct iterator in map range on binary values

### DIFF
--- a/_test/map28.go
+++ b/_test/map28.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/url"
 )
 
@@ -11,11 +10,12 @@ func main() {
 	value1.Set("first", "v1")
 	value1.Set("second", "v2")
 
+	l := 0
 	for k, v := range value1 {
-		fmt.Println("k:", k, "v:", v)
+		l += len(k) + len(v)
 	}
+	println(l)
 }
 
 // Output:
-// k: first v: [v1]
-// k: second v: [v2]
+// 13

--- a/_test/map28.go
+++ b/_test/map28.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func main() {
+	value1 := url.Values{}
+
+	value1.Set("first", "v1")
+	value1.Set("second", "v2")
+
+	for k, v := range value1 {
+		fmt.Println("k:", k, "v:", v)
+	}
+}
+
+// Output:
+// k: first v: [v1]
+// k: second v: [v2]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -89,6 +89,8 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						switch typ.Kind() {
 						case reflect.Map:
 							n.anc.gen = rangeMap
+							ityp := &itype{cat: valueT, rtype: reflect.TypeOf((*reflect.MapIter)(nil))}
+							sc.add(ityp)
 							ktyp = &itype{cat: valueT, rtype: typ.Key()}
 							vtyp = &itype{cat: valueT, rtype: typ.Elem()}
 						case reflect.String:


### PR DESCRIPTION
The map range iterator was not initialized correctly for values
originating from runtime.

Fixes #641.