### PR TITLE
interp: extend dot debugging

### DIFF
--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -72,6 +72,11 @@ Debugging support (may be removed at any time):
     Generate and display graphviz dot of AST with dotty(1)
   YAEGI_CFG_DOT=1
     Generate and display graphviz dot of CFG with dotty(1)
+  YAEGI_DOT_CMD='dot -Tsvg -ofoo.svg'
+    Defines how to process the dot code generated whenever YAEGI_AST_DOT and/or
+    YAEGI_CFG_DOT is enabled. If any of YAEGI_AST_DOT or YAEGI_CFG_DOT is set,
+    but YAEGI_DOT_CMD is not defined, the default is to write to a .dot file
+    next to the Go source file.
 */
 package main
 

--- a/interp/dot.go
+++ b/interp/dot.go
@@ -83,7 +83,7 @@ func dotWriter(dotCmd string) io.WriteCloser {
 	return dotin
 }
 
-func defaultDotCmd(filePath string) string {
+func defaultDotCmd(filePath, prefix string) string {
 	dir, fileName := filepath.Split(filePath)
 	ext := filepath.Ext(fileName)
 	if ext == "" {
@@ -91,5 +91,5 @@ func defaultDotCmd(filePath string) string {
 	} else {
 		fileName = strings.Replace(fileName, ext, ".dot", 1)
 	}
-	return "dot -Tdot -o" + dir + "yaegi-" + fileName
+	return "dot -Tdot -o" + dir + prefix + fileName
 }

--- a/interp/dot.go
+++ b/interp/dot.go
@@ -3,8 +3,10 @@ package interp
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -58,10 +60,19 @@ func (n *node) cfgDot(out io.Writer) {
 	fmt.Fprintf(out, "}\n")
 }
 
-// dotX returns an output stream to a dot(1) co-process where to write data in .dot format
-func dotX() io.WriteCloser {
-	cmd := exec.Command("dotty", "-")
-	//cmd := exec.Command("dot", "-T", "xlib")
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// dotWriter returns an output stream to a dot(1) co-process where to write data in .dot format
+func dotWriter(dotCmd string) io.WriteCloser {
+	if dotCmd == "" {
+		return nopCloser{ioutil.Discard}
+	}
+	fields := strings.Fields(dotCmd)
+	cmd := exec.Command(fields[0], fields[1:]...)
 	dotin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Fatal(err)
@@ -70,4 +81,15 @@ func dotX() io.WriteCloser {
 		log.Fatal(err)
 	}
 	return dotin
+}
+
+func defaultDotCmd(filePath string) string {
+	dir, fileName := filepath.Split(filePath)
+	ext := filepath.Ext(fileName)
+	if ext == "" {
+		fileName += ".dot"
+	} else {
+		fileName = strings.Replace(fileName, ext, ".dot", 1)
+	}
+	return "dot -Tdot -o" + dir + "yaegi-" + fileName
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -104,11 +104,11 @@ type imports map[string]map[string]*symbol
 
 // opt stores interpreter options
 type opt struct {
-	astDot   bool          // display AST graph (debug)
-	cfgDot   bool          // display CFG graph (debug)
+	astDot bool // display AST graph (debug)
+	cfgDot bool // display CFG graph (debug)
 	// dotCmd is the command to process the dot graph produced when astDot and/or
 	// cfgDot is enabled. It defaults to 'dot -Tdot -o <filename>.dot'.
-	dotCmd string
+	dotCmd   string
 	noRun    bool          // compile, but do not run
 	fastChan bool          // disable cancellable chan operations
 	context  build.Context // build context: GOPATH, build constraints
@@ -329,14 +329,6 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 		}
 	}()
 
-	var dotCmd string
-	if interp.astDot || interp.cfgDot {
-		dotCmd = interp.dotCmd
-		if dotCmd == "" {
-			dotCmd = defaultDotCmd(interp.Name)
-		}
-	}
-
 	// Parse source to AST.
 	pkgName, root, err := interp.ast(src, interp.Name)
 	if err != nil || root == nil {
@@ -344,6 +336,10 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 	}
 
 	if interp.astDot {
+		dotCmd := interp.dotCmd
+		if dotCmd == "" {
+			dotCmd = defaultDotCmd(interp.Name, "yaegi-ast-")
+		}
 		root.astDot(dotWriter(dotCmd), interp.Name)
 		if interp.noRun {
 			return res, err
@@ -379,6 +375,10 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 	interp.mutex.Unlock()
 
 	if interp.cfgDot {
+		dotCmd := interp.dotCmd
+		if dotCmd == "" {
+			dotCmd = defaultDotCmd(interp.Name, "yaegi-cfg-")
+		}
 		root.cfgDot(dotWriter(dotCmd))
 	}
 

--- a/interp/src.go
+++ b/interp/src.go
@@ -71,7 +71,7 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 		if interp.astDot {
 			dotCmd := interp.dotCmd
 			if dotCmd == "" {
-				dotCmd = defaultDotCmd(name)
+				dotCmd = defaultDotCmd(name, "yaegi-ast-")
 			}
 			root.astDot(dotWriter(dotCmd), name)
 		}

--- a/interp/src.go
+++ b/interp/src.go
@@ -67,8 +67,13 @@ func (interp *Interpreter) importSrc(rPath, path string) error {
 		if root == nil {
 			continue
 		}
+
 		if interp.astDot {
-			root.astDot(dotX(), name)
+			dotCmd := interp.dotCmd
+			if dotCmd == "" {
+				dotCmd = defaultDotCmd(name)
+			}
+			root.astDot(dotWriter(dotCmd), name)
 		}
 		if pkgName == "" {
 			pkgName = pname


### PR DESCRIPTION
As dotty does not seem to be readily available on MacOS, this PR extends
the ability to debug with dot, through the new YAEGI_DOT_CMD env var,
which allows one to specify the command to process the generated dot
graphs.

For example, to print the AST to svg:

YAEGI_AST_DOT=1 YAEGI_DOT_CMD='dot -Tsvg -ofoo.svg' yaegi ./foo.go

If any of YAEGI_AST_DOT or YAEGI_CFG_DOT is set, but YAEGI_DOT_CMD is
not defined, the default is to write to a .dot file next to the Go
source file.