### PR TITLE
fix: nil recover case

### DIFF
--- a/_test/recover2.go
+++ b/_test/recover2.go
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	println("hello")
+
+	var r interface{} = 1
+	r = recover()
+	if r == nil {
+		println("world")
+	}
+}
+
+// Output:
+// hello
+// world

--- a/interp/run.go
+++ b/interp/run.go
@@ -459,13 +459,9 @@ func _println(n *node) {
 func _recover(n *node) {
 	tnext := getExec(n.tnext)
 	dest := genValue(n)
-	var err error
-	nilErr := reflect.ValueOf(valueInterface{n, reflect.ValueOf(&err).Elem()})
 
 	n.exec = func(f *frame) bltn {
-		if f.anc.recovered == nil {
-			dest(f).Set(nilErr)
-		} else {
+		if f.anc.recovered != nil {
 			dest(f).Set(reflect.ValueOf(valueInterface{n, reflect.ValueOf(f.anc.recovered)}))
 			f.anc.recovered = nil
 		}


### PR DESCRIPTION
In the nil case for `recover` setting any value does not equate to nil. Doing nothing seems to do the trick. As part of the test I have ensured it overrides any existing value in the variable.

Fixes #659 