### PR TITLE
fix: handle empty interface conversion

### DIFF
--- a/_test/interface42.go
+++ b/_test/interface42.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	v := interface{}(0)
+	
+	fmt.Println(v)
+}
+
+// Output:
+// 0

--- a/_test/interface42.go
+++ b/_test/interface42.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func main() {
 	v := interface{}(0)
-	
+
 	fmt.Println(v)
 }
 

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -388,7 +388,8 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			return false
 
 		case interfaceType:
-			n.typ = sc.getType("interface{}")
+			//n.typ = sc.getType("interface{}")
+			n.typ, err = nodeType(interp, sc, n)
 			return false
 		}
 		return true

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -383,12 +383,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				}
 			}
 
-		case arrayType, basicLit, chanType, funcType, mapType, structType:
-			n.typ, err = nodeType(interp, sc, n)
-			return false
-
-		case interfaceType:
-			//n.typ = sc.getType("interface{}")
+		case arrayType, basicLit, chanType, funcType, interfaceType, mapType, structType:
 			n.typ, err = nodeType(interp, sc, n)
 			return false
 		}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -386,6 +386,10 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 		case arrayType, basicLit, chanType, funcType, mapType, structType:
 			n.typ, err = nodeType(interp, sc, n)
 			return false
+
+		case interfaceType:
+			n.typ = sc.getType("interface{}")
+			return false
 		}
 		return true
 	}, func(n *node) {


### PR DESCRIPTION
When an empty interface conversion was done, a panic was called due to the interface node type being nil. This handles this case.

Fixes #649 