### PR TITLE
fix: perform send channel action for select

### DIFF
--- a/_test/select12.go
+++ b/_test/select12.go
@@ -1,0 +1,23 @@
+package main
+
+type S struct {
+	q chan struct{}
+}
+
+func (s *S) Send() {
+	select {
+	case s.q <- struct{}{}:
+		println("sent")
+	default:
+		println("unexpected")
+	}
+}
+func main() {
+	s := &S{q: make(chan struct{}, 1)}
+	s.Send()
+	println("bye")
+}
+
+// Output:
+// sent
+// bye

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1444,6 +1444,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					cur.tnext = an.start
 				}
 				if pn != nil {
+					an.tnext = pn
 					cur = pn
 				}
 			}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1444,6 +1444,8 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					cur.tnext = an.start
 				}
 				if pn != nil {
+					// Chain channect init action to send data init action.
+					// (already done by wireChild, but let's be explicit).
 					an.tnext = pn
 					cur = pn
 				}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1446,7 +1446,6 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					cur = pn
 				}
 			}
-			// Invoke select action after the last channel init, o
 			if cur == nil {
 				// There is no channel init action, call select directly.
 				n.start = n.child[0]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1433,14 +1433,15 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 						pn = c0.child[1]
 					}
 				}
-				if an != nil {
-					if cur == nil {
-						// First channel init action, the entry point for the select block.
-						n.start = an.start
-					} else {
-						// Chain channel init action to the previous one.
-						cur.tnext = an.start
-					}
+				if an == nil {
+					continue
+				}
+				if cur == nil {
+					// First channel init action, the entry point for the select block.
+					n.start = an.start
+				} else {
+					// Chain channel init action to the previous one.
+					cur.tnext = an.start
 				}
 				if pn != nil {
 					cur = pn


### PR DESCRIPTION
The CFG was wrong for select send comm clauses. If an init operation
on channel was required (like a derefence, index operation, ...) it
 was skipped. The bug was invisible in case of a local var channel.
    
 A send channel init operation consist to prepare both the data to
 send (right subtree of send AST) and the channel itself (left
 subtree of send AST). All channel init operation must be performed
 prior to call select.
    
 Fixes #647.