### PR TITLE
fix: composite literal child types for call expressions

### DIFF
--- a/_test/composite10.go
+++ b/_test/composite10.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := []map[int]int{make(map[int]int)}
+
+	for _, b := range a {
+		fmt.Println(b)
+	}
+}
+
+// Output:
+// map[]

--- a/_test/composite9.go
+++ b/_test/composite9.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := [][]int{make([]int,0)}
+
+	for _, b := range a {
+		fmt.Println(b)
+	}
+}
+
+// Output:
+// []

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -248,6 +248,10 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				case binaryExpr, unaryExpr:
 					// Do not attempt to propagate composite type to operator expressions,
 					// it breaks constant folding.
+				case callExpr:
+					if c.typ, err = nodeType(interp, sc, c); err != nil {
+						return false
+					}
 				default:
 					c.typ = n.typ
 				}


### PR DESCRIPTION
In the case of a call expression (make) in a composite literal expression, the node type is not correct, rather the call expression needs the actual type it will return.

Fixes #651