### PR TITLE
fix: handle range on chan function return

### DIFF
--- a/_test/range7.go
+++ b/_test/range7.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+)
+
+func someChan() <-chan struct{} {
+	c := make(chan struct{}, 1)
+	c <- struct{}{}
+	return c
+}
+
+func main() {
+	for _ = range someChan() {
+		fmt.Println("success")
+		return
+	}
+}
+
+// Output:
+// success

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -135,6 +135,9 @@ func (s *scope) rangeChanType(n *node) *itype {
 			return t
 		}
 	}
+	if c := n.child[1]; c.typ != nil && c.typ.cat == chanT {
+		return n.child[1].typ
+	}
 	return nil
 }
 

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -136,7 +136,7 @@ func (s *scope) rangeChanType(n *node) *itype {
 		}
 	}
 	if c := n.child[1]; c.typ != nil && c.typ.cat == chanT {
-		return n.child[1].typ
+		return c.typ
 	}
 	return nil
 }


### PR DESCRIPTION
When ranging a channel from a function return, the return was not detected as a chan type. This attempts to fix this.

It is possible this needs to come out of the scope `rangeChanType` function and rather be part of `cfg.go`?

Fixes #667