### PR TITLE
Travis: apply timeout multiplier on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
 env:
   global:
     - GO111MODULE=on
+    - CI=1
 
 go_import_path: github.com/containous/yaegi
 


### PR DESCRIPTION
On my local machine, the 100 ms timeout in TestYaegiCmdCancel is not
enough to make the test pass.

So instead of hardcoding it to a larger
value, this PR adds the same kind of technique as is used in Traefik to
make the timeouts longer when they are run on the CI. Which allows me to
make the test pass on my local machine as well, by forcing the CI env
variable to true.