### PR TITLE
fix: handle call ellipsis

### DIFF
--- a/_test/variadic7.go
+++ b/_test/variadic7.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a, b string
+
+	pattern := "%s %s"
+	dest := []interface{}{&a, &b}
+
+	n, err := fmt.Sscanf("test1 test2", pattern, dest...)
+	if err != nil || n != len(dest) {
+		println("error")
+		return
+	}
+	println(a, b)
+}
+
+// Output:
+// test1 test2

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -197,6 +197,7 @@ const (
 	aBitNot
 	aBranch
 	aCall
+	aCallSlice
 	aCase
 	aCompositeLit
 	aConvert
@@ -258,6 +259,7 @@ var actions = [...]string{
 	aBitNot:       "^",
 	aBranch:       "branch",
 	aCall:         "call",
+	aCallSlice:    "callSlice",
 	aCase:         "case",
 	aCompositeLit: "compositeLit",
 	aConvert:      "convert",
@@ -549,7 +551,12 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 			st.push(addChild(&root, anc, pos, kind, aNop), nod)
 
 		case *ast.CallExpr:
-			st.push(addChild(&root, anc, pos, callExpr, aCall), nod)
+			action := aCall
+			if a.Ellipsis != token.NoPos {
+				action = aCallSlice
+			}
+
+			st.push(addChild(&root, anc, pos, callExpr, action), nod)
 
 		case *ast.CaseClause:
 			st.push(addChild(&root, anc, pos, caseClause, aCase), nod)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -499,7 +499,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				// Propagate type
 				// TODO: Check that existing destination type matches source type
 				switch {
-				case n.action == aAssign && src.action == aCall && dest.typ.cat != interfaceT && !isRecursiveField(dest):
+				case n.action == aAssign && isCall(src) && dest.typ.cat != interfaceT && !isRecursiveField(dest):
 					// Call action may perform the assignment directly.
 					n.gen = nop
 					src.level = level
@@ -827,7 +827,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				typ := n.child[0].typ.rtype
 				numIn := len(n.child) - 1
 				tni := typ.NumIn()
-				if numIn == 1 && n.child[1].action == aCall {
+				if numIn == 1 && isCall(n.child[1]) {
 					numIn = n.child[1].typ.numOut()
 				}
 				if n.child[0].action == aGetMethod {
@@ -1224,7 +1224,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 		case returnStmt:
 			if mustReturnValue(sc.def.child[2]) {
 				nret := len(n.child)
-				if nret == 1 && n.child[0].action == aCall {
+				if nret == 1 && isCall(n.child[0]) {
 					nret = n.child[0].child[0].typ.numOut()
 				}
 				if nret < sc.def.typ.numOut() {
@@ -2030,6 +2030,10 @@ func isMethod(n *node) bool {
 
 func isMapEntry(n *node) bool {
 	return n.action == aGetIndex && isMap(n.child[0].typ)
+}
+
+func isCall(n *node) bool {
+	return n.action == aCall || n.action == aCallSlice
 }
 
 func isBinCall(n *node) bool {

--- a/interp/run.go
+++ b/interp/run.go
@@ -26,6 +26,7 @@ var builtin = [...]bltnGenerator{
 	aAndNotAssign: andNotAssign,
 	aBitNot:       bitNot,
 	aCall:         call,
+	aCallSlice:    call,
 	aCase:         _case,
 	aCompositeLit: arrayLit,
 	aDec:          dec,
@@ -1019,7 +1020,7 @@ func callBin(n *node) {
 }
 
 func getIndexBinMethod(n *node) {
-	//dest := genValue(n)
+	// dest := genValue(n)
 	i := n.findex
 	m := n.val.(int)
 	value := genValue(n.child[0])
@@ -1027,7 +1028,7 @@ func getIndexBinMethod(n *node) {
 
 	n.exec = func(f *frame) bltn {
 		// Can not use .Set() because dest type contains the receiver and source not
-		//dest(f).Set(value(f).Method(m))
+		// dest(f).Set(value(f).Method(m))
 		f.data[i] = value(f).Method(m)
 		return next
 	}
@@ -1623,7 +1624,7 @@ func _return(n *node) {
 	case 0:
 		n.exec = nil
 	case 1:
-		if child[0].kind == binaryExpr || child[0].action == aCall {
+		if child[0].kind == binaryExpr || isCall(child[0]) {
 			n.exec = nil
 		} else {
 			v := values[0]

--- a/interp/value.go
+++ b/interp/value.go
@@ -166,6 +166,19 @@ func genValueRangeArray(n *node) func(*frame) reflect.Value {
 	}
 }
 
+func genValueInterfaceArray(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+	return func(f *frame) reflect.Value {
+		vi := value(f).Interface().([]valueInterface)
+		v := reflect.MakeSlice(reflect.TypeOf([]interface{}{}), len(vi), len(vi))
+		for i, vv := range vi {
+			v.Index(i).Set(vv.value)
+		}
+
+		return v
+	}
+}
+
 func genValueInterfacePtr(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 


### PR DESCRIPTION
While variable expansion is not an issue in interpreter calls, in binary calls they need to be handled, otherwise the sees the expanded variable only. This introduces `aCallSlice` action when the `callExpr` has an ellipsis. As some code checks for `aCall` an `isCall` function is also added to be used in these cases.

Fixes #675