### PR TITLE
fix: array recursion

### DIFF
--- a/_test/struct23.go
+++ b/_test/struct23.go
@@ -1,15 +1,23 @@
 package main
 
+import (
+	"encoding/json"
+	"os"
+)
+
 type S struct {
-	Child []*S
 	Name  string
+	Child []*S
 }
 
 func main() {
-	s := &S{Name: "root"}
-	s.Child = append(s.Child, &S{Name: "child"})
-	println(s.Child[0].Name)
+	a := S{Name: "hello"}
+	a.Child = append(a.Child, &S{Name: "world"})
+	json.NewEncoder(os.Stdout).Encode(a)
+	a.Child[0].Child = append([]*S{}, &S{Name: "sunshine"})
+	json.NewEncoder(os.Stdout).Encode(a)
 }
 
-// Output:
-// child
+// Outputs:
+// {"Name":"hello","Child":[{"Name":"world","Child":null}]}
+// {"Name":"hello","Child":[{"Name":"world","Child":[{"Name":"sunshine","Child":null}]}]}

--- a/_test/struct49.go
+++ b/_test/struct49.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type Node struct {
+	Name  string
+	Child []Node
+}
+
+func main() {
+	a := Node{Name: "hello"}
+	a.Child = append([]Node{}, Node{Name: "world"})
+	fmt.Println(a)
+	a.Child[0].Child = append([]Node{}, Node{Name: "sunshine"})
+	fmt.Println(a)
+}
+
+// Outputs:
+// {hello [{world []}]}
+// {hello [{world [{sunshine []}]}]}

--- a/_test/struct50.go
+++ b/_test/struct50.go
@@ -1,0 +1,13 @@
+package main
+
+type Node struct {
+	foo []*Node
+}
+
+func main() {
+	a := Node{foo: []*Node{{}}}
+	println(len(a.foo))
+}
+
+// Output:
+// 1

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2090,7 +2090,17 @@ func isField(n *node) bool {
 }
 
 func isRecursiveField(n *node) bool {
-	return isField(n) && (n.typ.recursive || n.typ.cat == ptrT && n.typ.val.recursive)
+	if !isField(n) {
+		return false
+	}
+	t := n.typ
+	for t != nil {
+		if t.recursive {
+			return true
+		}
+		t = t.val
+	}
+	return false
 }
 
 // isNewDefine returns true if node refers to a new definition.

--- a/interp/run.go
+++ b/interp/run.go
@@ -2020,6 +2020,10 @@ func doCompositeSparse(n *node, hasType bool) {
 			values[field] = genFunctionWrapper(c1)
 		case isRecursiveStruct(n.typ.field[field].typ, n.typ.field[field].typ.rtype):
 			values[field] = genValueInterfacePtr(c1)
+		case isRecursiveArrayStruct(n.typ.field[field].typ, n.typ.field[field].typ.rtype) && n.typ.field[field].typ.val.cat == ptrT:
+			values[field] = genValueArrayInterfacePtr(c1)
+		case isRecursiveArrayStruct(n.typ.field[field].typ, n.typ.field[field].typ.rtype):
+			values[field] = genValueArrayInterface(c1)
 		default:
 			values[field] = genValue(c1)
 		}

--- a/interp/value.go
+++ b/interp/value.go
@@ -182,6 +182,45 @@ func genValueInterfaceArray(n *node) func(*frame) reflect.Value {
 	}
 }
 
+var sliceInter = reflect.TypeOf((*[]*interface{})(nil)).Elem()
+
+func genValueArrayInterface(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+	return func(f *frame) reflect.Value {
+		vi := value(f)
+		if vi.Type() == sliceInter {
+			return vi
+		}
+		l := vi.Len()
+		v := reflect.MakeSlice(reflect.TypeOf([]interface{}{}), l, l)
+		for i := 0; i < l; i++ {
+			v.Index(i).Set(vi.Index(i))
+		}
+
+		return v
+	}
+}
+
+var slicePtrInter = reflect.TypeOf((*[]*interface{})(nil)).Elem()
+
+func genValueArrayInterfacePtr(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+	return func(f *frame) reflect.Value {
+		vi := value(f)
+		if vi.Type() == slicePtrInter {
+			return vi
+		}
+		l := vi.Len()
+		v := reflect.MakeSlice(reflect.TypeOf([]*interface{}{}), l, l)
+		for i := 0; i < l; i++ {
+			val := vi.Index(i).Interface()
+			v.Index(i).Set(reflect.ValueOf(&val))
+		}
+
+		return v
+	}
+}
+
 func genValueInterfacePtr(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 


### PR DESCRIPTION
This handles the missing parts of array recursion.

@mvertes This contains `unsafe` when trying to reference the interface, but I see no other way to make it work.