### PR TITLE
feature: add Sizeof and Alignof to unsafe

### DIFF
--- a/_test/unsafe5.go
+++ b/_test/unsafe5.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type S struct {
+	X int
+	Y int
+	Z int
+}
+
+func main() {
+	size := unsafe.Sizeof(S{})
+	align := unsafe.Alignof(S{})
+
+	fmt.Println(size, align)
+}
+
+// Output:
+// 24 8

--- a/interp/hooks.go
+++ b/interp/hooks.go
@@ -1,0 +1,30 @@
+package interp
+
+import "reflect"
+
+const hooksPath = "github.com/containous/yaegi"
+
+// convertFn is the signature of a symbol converter.
+type convertFn func(from, to reflect.Type) func(src, dest reflect.Value)
+
+// hooks are external symbol bindings.
+type hooks struct {
+	convert []convertFn
+}
+
+func (h *hooks) Parse(m map[string]reflect.Value) {
+	if con, ok := getConvertFn(m["convert"]); ok {
+		h.convert = append(h.convert, con)
+	}
+}
+
+func getConvertFn(v reflect.Value) (convertFn, bool) {
+	if !v.IsValid() {
+		return nil, false
+	}
+	fn, ok := v.Interface().(func(from, to reflect.Type) func(src, dest reflect.Value))
+	if !ok {
+		return nil, false
+	}
+	return fn, true
+}

--- a/interp/run.go
+++ b/interp/run.go
@@ -329,7 +329,7 @@ func convert(n *node) {
 		value = genValue(c)
 	}
 
-	for _, con := range n.interp.convert {
+	for _, con := range n.interp.hooks.convert {
 		if c.typ.rtype == nil {
 			continue
 		}

--- a/stdlib/unsafe/unsafe.go
+++ b/stdlib/unsafe/unsafe.go
@@ -18,6 +18,10 @@ func init() {
 	Symbols["github.com/containous/yaegi"] = map[string]reflect.Value{
 		"convert": reflect.ValueOf(convert),
 	}
+
+	// Add builtin functions to unsafe.
+	Symbols["unsafe"]["Sizeof"] = reflect.ValueOf(sizeof)
+	Symbols["unsafe"]["Alignof"] = reflect.ValueOf(alignof)
 }
 
 func convert(from, to reflect.Type) func(src, dest reflect.Value) {
@@ -44,6 +48,14 @@ func convert(from, to reflect.Type) func(src, dest reflect.Value) {
 	default:
 		return nil
 	}
+}
+
+func sizeof(i interface{}) uintptr {
+	return reflect.ValueOf(i).Type().Size()
+}
+
+func alignof(i interface{}) uintptr {
+	return uintptr(reflect.ValueOf(i).Type().Align())
 }
 
 //go:generate ../../cmd/goexports/goexports unsafe


### PR DESCRIPTION
This adds `Sizeof` and `Alignof` to `unsafe`. Without access to the `node`, I dont see a way to add `Offsetof`, so it is left out for now.

The hook logic was also moved out of the interpreter, to keep it a little cleaner. This should also make any further extensions easier to fit in without changes to the interpreter code.