### PR TITLE
fix: make reftype func variadic

### DIFF
--- a/_test/variadic8.go
+++ b/_test/variadic8.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fn1 := func(args ...*time.Duration) string {
+		return ""
+	}
+
+	fmt.Printf("%T\n", fn1)
+}
+
+// Output:
+// func(...*time.Duration) string

--- a/interp/type.go
+++ b/interp/type.go
@@ -1181,15 +1181,17 @@ func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.T
 		if t.name != "" {
 			defined[name] = t
 		}
+		variadic := false
 		in := make([]reflect.Type, len(t.arg))
 		out := make([]reflect.Type, len(t.ret))
 		for i, v := range t.arg {
 			in[i] = v.refType(defined, true)
+			variadic = v.cat == variadicT
 		}
 		for i, v := range t.ret {
 			out[i] = v.refType(defined, true)
 		}
-		t.rtype = reflect.FuncOf(in, out, false)
+		t.rtype = reflect.FuncOf(in, out, variadic)
 	case interfaceT:
 		t.rtype = interf
 	case mapT:


### PR DESCRIPTION
A refType function should be marked as variadic if it is.

Fixes #697