### PR TITLE
fix: use pragma for ptr checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,3 @@
-GO_VERSION=$(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1,2)
-
-RACE_TEST_GCFLAGS=
-ifneq ($(GO_VERSION), 1.13)
-# support for unsafe means we cannot do unsafe pointer arithmetic checks
-RACE_TEST_GCFLAGS=-gcflags=all=-d=checkptr=0
-endif
-
 # Static linting of source files. See .golangci.toml for options
 check:
 	golangci-lint run
@@ -26,6 +18,6 @@ generate: gen_all_syscall
 
 tests:
 	GO111MODULE=off go test -v ./...
-	GO111MODULE=off go test -race $(RACE_TEST_GCFLAGS) -short ./interp
+	GO111MODULE=off go test -race ./interp
 
 .PHONY: check gen_all_syscall gen_tests

--- a/stdlib/unsafe/unsafe.go
+++ b/stdlib/unsafe/unsafe.go
@@ -27,9 +27,7 @@ func init() {
 func convert(from, to reflect.Type) func(src, dest reflect.Value) {
 	switch {
 	case to.Kind() == reflect.UnsafePointer && from.Kind() == reflect.Uintptr:
-		return func(src, dest reflect.Value) {
-			dest.SetPointer(unsafe.Pointer(src.Interface().(uintptr))) //nolint:govet
-		}
+		return uintptrToUnsafePtr
 	case to.Kind() == reflect.UnsafePointer:
 		return func(src, dest reflect.Value) {
 			dest.SetPointer(unsafe.Pointer(src.Pointer()))
@@ -56,6 +54,11 @@ func sizeof(i interface{}) uintptr {
 
 func alignof(i interface{}) uintptr {
 	return uintptr(reflect.ValueOf(i).Type().Align())
+}
+
+//go:nocheckptr
+func uintptrToUnsafePtr(src, dest reflect.Value) {
+	dest.SetPointer(unsafe.Pointer(src.Interface().(uintptr))) //nolint:govet
 }
 
 //go:generate ../../cmd/goexports/goexports unsafe


### PR DESCRIPTION
It turns out there is a go pragma to turn off pointer checks. This is preferable to turning them off completely.