### PR TITLE
feature: handle nested recursion

### DIFF
--- a/_test/struct23.go
+++ b/_test/struct23.go
@@ -1,15 +1,23 @@
 package main
 
+import (
+	"encoding/json"
+	"os"
+)
+
 type S struct {
-	Child []*S
 	Name  string
+	Child []*S
 }
 
 func main() {
-	s := &S{Name: "root"}
-	s.Child = append(s.Child, &S{Name: "child"})
-	println(s.Child[0].Name)
+	a := S{Name: "hello"}
+	a.Child = append(a.Child, &S{Name: "world"})
+	json.NewEncoder(os.Stdout).Encode(a)
+	a.Child[0].Child = append([]*S{}, &S{Name: "sunshine"})
+	json.NewEncoder(os.Stdout).Encode(a)
 }
 
 // Output:
-// child
+// {"Name":"hello","Child":[{"Name":"world","Child":null}]}
+// {"Name":"hello","Child":[{"Name":"world","Child":[{"Name":"sunshine","Child":null}]}]}

--- a/_test/struct49.go
+++ b/_test/struct49.go
@@ -1,0 +1,31 @@
+package main
+
+type S struct {
+	ts map[string][]*T
+}
+
+func (c *S) getT(addr string) *T {
+	cns, ok := c.ts[addr]
+	if !ok || len(cns) == 0 {
+		return nil
+	}
+
+	return cns[0]
+}
+
+type T struct {
+	s *S
+}
+
+func main() {
+	s := &S{
+		ts: map[string][]*T{},
+	}
+	s.ts["test"] = append(s.ts["test"], &T{s: s})
+
+	t := s.getT("test")
+	println(t != nil)
+}
+
+// Output:
+// true

--- a/_test/struct49.go
+++ b/_test/struct49.go
@@ -4,17 +4,19 @@ type S struct {
 	ts map[string][]*T
 }
 
-func (c *S) getT(addr string) *T {
-	cns, ok := c.ts[addr]
-	if !ok || len(cns) == 0 {
-		return nil
-	}
-
-	return cns[0]
-}
-
 type T struct {
 	s *S
+}
+
+func (c *S) getT(addr string) (t *T, ok bool) {
+	cns, ok := c.ts[addr]
+	if !ok || len(cns) == 0 {
+		return nil, false
+	}
+
+	t = cns[len(cns)-1]
+	c.ts[addr] = cns[:len(cns)-1]
+	return t, true
 }
 
 func main() {
@@ -23,9 +25,9 @@ func main() {
 	}
 	s.ts["test"] = append(s.ts["test"], &T{s: s})
 
-	t := s.getT("test")
-	println(t != nil)
+	t , ok:= s.getT("test")
+	println(t != nil, ok)
 }
 
 // Output:
-// true
+// true true

--- a/_test/struct50.go
+++ b/_test/struct50.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type Node struct {
+	Name  string
+	Child []Node
+}
+
+func main() {
+	a := Node{Name: "hello"}
+	a.Child = append([]Node{}, Node{Name: "world"})
+	fmt.Println(a)
+	a.Child[0].Child = append([]Node{}, Node{Name: "sunshine"})
+	fmt.Println(a)
+}
+
+// Output:
+// {hello [{world []}]}
+// {hello [{world [{sunshine []}]}]}

--- a/_test/struct51.go
+++ b/_test/struct51.go
@@ -1,20 +1,23 @@
 package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"os"
+)
 
 type Node struct {
 	Name  string
-	Child [2]Node
+	Child [2]*Node
 }
 
 func main() {
 	a := Node{Name: "hello"}
-	a.Child[0] = Node{Name: "world"}
-	fmt.Println(a)
-	a.Child[0].Child[0] = Node{Name: "sunshine"}
-	fmt.Println(a)
+	a.Child[0] = &Node{Name: "world"}
+	json.NewEncoder(os.Stdout).Encode(a)
+	a.Child[0].Child[0] = &Node{Name: "sunshine"}
+	json.NewEncoder(os.Stdout).Encode(a)
 }
 
 // Output:
-// {hello [{world [<nil> <nil>]} <nil>]}
-// {hello [{world [{sunshine [<nil> <nil>]} <nil>]} <nil>]}
+// {"Name":"hello","Child":[{"Name":"world","Child":[null,null]},null]}
+// {"Name":"hello","Child":[{"Name":"world","Child":[{"Name":"sunshine","Child":[null,null]},null]},null]}

--- a/_test/struct51.go
+++ b/_test/struct51.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type Node struct {
+	Name  string
+	Child [2]Node
+}
+
+func main() {
+	a := Node{Name: "hello"}
+	a.Child[0] = Node{Name: "world"}
+	fmt.Println(a)
+	a.Child[0].Child[0] = Node{Name: "sunshine"}
+	fmt.Println(a)
+}
+
+// Output:
+// {hello [{world [<nil> <nil>]} <nil>]}
+// {hello [{world [{sunshine [<nil> <nil>]} <nil>]} <nil>]}

--- a/_test/struct52.go
+++ b/_test/struct52.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type Node struct {
+	Name  string
+	Child map[string]Node
+}
+
+func main() {
+	a := Node{Name: "hello", Child: map[string]Node{}}
+	a.Child["1"] = Node{Name: "world", Child: map[string]Node{}}
+	fmt.Println(a)
+	a.Child["1"].Child["1"] = Node{Name: "sunshine", Child: map[string]Node{}}
+	fmt.Println(a)
+}
+
+// Output:
+// {hello map[1:{world map[]}]}
+// {hello map[1:{world map[1:{sunshine map[]}]}]}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2142,7 +2142,17 @@ func isField(n *node) bool {
 }
 
 func isRecursiveField(n *node) bool {
-	return isField(n) && (n.typ.recursive || n.typ.cat == ptrT && n.typ.val.recursive)
+	if !isField(n) {
+		return false
+	}
+	t := n.typ
+	for t != nil {
+		if t.recursive {
+			return true
+		}
+		t = t.val
+	}
+	return false
 }
 
 // isNewDefine returns true if node refers to a new definition.

--- a/interp/run.go
+++ b/interp/run.go
@@ -355,8 +355,8 @@ func isRecursiveStruct(t *itype, rtype reflect.Type) bool {
 	if t.cat == structT && rtype.Kind() == reflect.Interface {
 		return true
 	}
-	if t.cat == ptrT && t.rtype != nil {
-		return isRecursiveStruct(t.val, t.rtype.Elem())
+	if t.cat == ptrT && t.val.rtype != nil {
+		return isRecursiveStruct(t.val, t.val.rtype)
 	}
 	return false
 }

--- a/interp/run.go
+++ b/interp/run.go
@@ -7,6 +7,7 @@ import (
 	"go/constant"
 	"log"
 	"reflect"
+	"unsafe"
 )
 
 // bltn type defines functions which run at CFG execution.
@@ -351,14 +352,16 @@ func convert(n *node) {
 	}
 }
 
-func isRecursiveStruct(t *itype, rtype reflect.Type) bool {
+func isRecursiveType(t *itype, rtype reflect.Type) bool {
 	if t.cat == structT && rtype.Kind() == reflect.Interface {
 		return true
 	}
-	if t.cat == ptrT && t.val.rtype != nil {
-		return isRecursiveStruct(t.val, t.val.rtype)
+	switch t.cat {
+	case ptrT, arrayT, mapT:
+		return isRecursiveType(t.val, t.val.rtype)
+	default:
+		return false
 	}
-	return false
 }
 
 func assign(n *node) {
@@ -387,8 +390,8 @@ func assign(n *node) {
 		case src.kind == basicLit && src.val == nil:
 			t := dest.typ.TypeOf()
 			svalue[i] = func(*frame) reflect.Value { return reflect.New(t).Elem() }
-		case isRecursiveStruct(dest.typ, dest.typ.rtype):
-			svalue[i] = genValueInterfacePtr(src)
+		case isRecursiveType(dest.typ, dest.typ.rtype):
+			svalue[i] = genValueRecursiveInterface(src, dest.typ.rtype)
 		case src.typ.untyped && isComplex(dest.typ.TypeOf()):
 			svalue[i] = genValueComplex(src)
 		case src.typ.untyped && !dest.typ.untyped:
@@ -762,7 +765,7 @@ func call(n *node) {
 	var values []func(*frame) reflect.Value
 	if n.child[0].recv != nil {
 		// Compute method receiver value.
-		if isRecursiveStruct(n.child[0].recv.node.typ, n.child[0].recv.node.typ.rtype) {
+		if isRecursiveType(n.child[0].recv.node.typ, n.child[0].recv.node.typ.rtype) {
 			values = append(values, genValueRecvInterfacePtr(n.child[0]))
 		} else {
 			values = append(values, genValueRecv(n.child[0]))
@@ -808,8 +811,8 @@ func call(n *node) {
 			switch {
 			case len(n.child[0].typ.arg) > i && n.child[0].typ.arg[i].cat == interfaceT:
 				values = append(values, genValueInterface(c))
-			case isRecursiveStruct(c.typ, c.typ.rtype):
 				values = append(values, genValueDerefInterfacePtr(c))
+			case isRecursiveType(c.typ, c.typ.rtype):
 			default:
 				values = append(values, genValue(c))
 			}
@@ -1498,7 +1501,14 @@ func getIndexSeq(n *node) {
 	if n.fnext != nil {
 		fnext := getExec(n.fnext)
 		n.exec = func(f *frame) bltn {
-			f.data[i] = value(f).FieldByIndex(index)
+			v := value(f)
+			if v.Type().Kind() == reflect.Interface && n.child[0].typ.recursive {
+				// Here we have an interface to a struct. Any attempt to dereference it will
+				// make a copy of the struct. We need to get a Value to the actual struct.
+				// TODO: using unsafe is a temporary measure. Rethink this.
+				v = reflect.NewAt(v.Elem().Type(), unsafe.Pointer(v.InterfaceData()[1])).Elem() //nolint:govet
+			}
+			f.data[i] = v.FieldByIndex(index)
 			if f.data[i].Bool() {
 				return tnext
 			}
@@ -1506,7 +1516,14 @@ func getIndexSeq(n *node) {
 		}
 	} else {
 		n.exec = func(f *frame) bltn {
-			f.data[i] = value(f).FieldByIndex(index)
+			v := value(f)
+			if v.Type().Kind() == reflect.Interface && n.child[0].typ.recursive {
+				// Here we have an interface to a struct. Any attempt to dereference it will
+				// make a copy of the struct. We need to get a Value to the actual struct.
+				// TODO: using unsafe is a temporary measure. Rethink this.
+				v = reflect.NewAt(v.Elem().Type(), unsafe.Pointer(v.InterfaceData()[1])).Elem() //nolint:govet
+			}
+			f.data[i] = v.FieldByIndex(index)
 			return tnext
 		}
 	}
@@ -1516,7 +1533,7 @@ func getPtrIndexSeq(n *node) {
 	index := n.val.([]int)
 	tnext := getExec(n.tnext)
 	var value func(*frame) reflect.Value
-	if isRecursiveStruct(n.child[0].typ, n.child[0].typ.rtype) {
+	if isRecursiveType(n.child[0].typ, n.child[0].typ.rtype) {
 		v := genValue(n.child[0])
 		value = func(f *frame) reflect.Value { return v(f).Elem().Elem() }
 	} else {
@@ -2033,8 +2050,8 @@ func doCompositeSparse(n *node, hasType bool) {
 		switch {
 		case c1.typ.cat == funcT:
 			values[field] = genFunctionWrapper(c1)
-		case isRecursiveStruct(n.typ.field[field].typ, n.typ.field[field].typ.rtype):
-			values[field] = genValueInterfacePtr(c1)
+		case isRecursiveType(n.typ.field[field].typ, n.typ.field[field].typ.rtype):
+			values[field] = genValueRecursiveInterface(c1, n.typ.field[field].typ.rtype)
 		default:
 			values[field] = genValue(c1)
 		}
@@ -2336,8 +2353,8 @@ func _append(n *node) {
 			switch {
 			case n.typ.val.cat == interfaceT:
 				values[i] = genValueInterface(arg)
-			case isRecursiveStruct(n.typ.val, n.typ.val.rtype):
-				values[i] = genValueInterfacePtr(arg)
+			case isRecursiveType(n.typ.val, n.typ.val.rtype):
+				values[i] = genValueRecursiveInterface(arg, n.typ.val.rtype)
 			case arg.typ.untyped:
 				values[i] = genValueAs(arg, n.child[1].typ.TypeOf().Elem())
 			default:
@@ -2358,8 +2375,8 @@ func _append(n *node) {
 		switch {
 		case n.typ.val.cat == interfaceT:
 			value0 = genValueInterface(n.child[2])
-		case isRecursiveStruct(n.typ.val, n.typ.val.rtype):
-			value0 = genValueInterfacePtr(n.child[2])
+		case isRecursiveType(n.typ.val, n.typ.val.rtype):
+			value0 = genValueRecursiveInterface(n.child[2], n.typ.val.rtype)
 		case n.child[2].typ.untyped:
 			value0 = genValueAs(n.child[2], n.child[1].typ.TypeOf().Elem())
 		default:

--- a/interp/run.go
+++ b/interp/run.go
@@ -392,6 +392,8 @@ func assign(n *node) {
 			svalue[i] = func(*frame) reflect.Value { return reflect.New(t).Elem() }
 		case isRecursiveType(dest.typ, dest.typ.rtype):
 			svalue[i] = genValueRecursiveInterface(src, dest.typ.rtype)
+		case isRecursiveType(src.typ, src.typ.rtype):
+			svalue[i] = genValueRecursiveInterfacePtrValue(src)
 		case src.typ.untyped && isComplex(dest.typ.TypeOf()):
 			svalue[i] = genValueComplex(src)
 		case src.typ.untyped && !dest.typ.untyped:

--- a/interp/run.go
+++ b/interp/run.go
@@ -1482,6 +1482,7 @@ func getMethodByName(n *node) {
 	}
 }
 
+//go:nocheckptr
 func getIndexSeq(n *node) {
 	value := genValue(n.child[0])
 	index := n.val.([]int)

--- a/interp/run.go
+++ b/interp/run.go
@@ -811,8 +811,8 @@ func call(n *node) {
 			switch {
 			case len(n.child[0].typ.arg) > i && n.child[0].typ.arg[i].cat == interfaceT:
 				values = append(values, genValueInterface(c))
-				values = append(values, genValueDerefInterfacePtr(c))
 			case isRecursiveType(c.typ, c.typ.rtype):
+				values = append(values, genValueRecursiveInterfacePtrValue(c))
 			default:
 				values = append(values, genValue(c))
 			}

--- a/interp/type.go
+++ b/interp/type.go
@@ -1255,6 +1255,8 @@ func (t *itype) refType(defined map[string]*itype, wrapRecursive bool) reflect.T
 	if t.val != nil && defined[t.val.path+"/"+t.val.name] != nil && t.val.rtype == nil {
 		// Replace reference to self (direct or indirect) by an interface{} to handle
 		// recursive types with reflect.
+		typ := *t.val
+		t.val = &typ
 		t.val.rtype = interf
 		recursive = true
 	}

--- a/interp/value.go
+++ b/interp/value.go
@@ -201,18 +201,6 @@ func genValueInterface(n *node) func(*frame) reflect.Value {
 	}
 }
 
-func genValueDerefInterfacePtr(n *node) func(*frame) reflect.Value {
-	value := genValue(n)
-
-	return func(f *frame) reflect.Value {
-		v := value(f)
-		if v.IsZero() {
-			return v
-		}
-		return v.Elem().Elem()
-	}
-}
-
 func zeroInterfaceValue() reflect.Value {
 	n := &node{kind: basicLit, typ: &itype{cat: nilT, untyped: true}}
 	v := reflect.New(interf).Elem()
@@ -301,6 +289,18 @@ func toRecursive(dest, src reflect.Value) {
 		dest.Set(v.Addr())
 	default:
 		dest.Set(src)
+	}
+}
+
+func genValueRecursiveInterfacePtrValue(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+
+	return func(f *frame) reflect.Value {
+		v := value(f)
+		if v.IsZero() {
+			return v
+		}
+		return v.Elem().Elem()
 	}
 }
 


### PR DESCRIPTION
Nested recursion brings about a problem of different reflect types for each struct. To align the reflect types and be able to handle recursive conversions, all intermediate structs should also have an `interface{}` reflect type. It is also possible that the recursive type can have an arbitrary depth, making handling this conversion on a case by case bases impractical if not impossible. A more generic approach has been taken to handle this more gracefully.

Due to the lack on interface wrapper at this point, the only way to dereference a `[]interface{}` in a writable form is to use `reflect.NewAt` with `unsafe`. The inclusion of `unsafe` is not idea, but all other methods have consequences that effect other parts. This change should be considered temporary until another work around can be found.

Fixes #716 #687