### PR TITLE
fix: variadic interface conversion in call/callBin

### DIFF
--- a/_test/variadic9.go
+++ b/_test/variadic9.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, a...)
+}
+
+func main() {
+	fmt.Println(Sprintf("Hello %s", "World!"))
+}
+
+// Output:
+// Hello World!

--- a/interp/run.go
+++ b/interp/run.go
@@ -801,17 +801,18 @@ func call(n *node) {
 				values = append(values, func(f *frame) reflect.Value { return f.data[ind] })
 			}
 		default:
+			var arg *itype
+			if variadic >= 0 && i >= variadic {
+				arg = n.child[0].typ.arg[variadic].val
+			} else {
+				arg = n.child[0].typ.arg[i]
+			}
 			if c.kind == basicLit || c.rval.IsValid() {
-				var argType reflect.Type
-				if variadic >= 0 && i >= variadic {
-					argType = n.child[0].typ.arg[variadic].val.TypeOf()
-				} else {
-					argType = n.child[0].typ.arg[i].TypeOf()
-				}
+				argType := arg.TypeOf()
 				convertLiteralValue(c, argType)
 			}
 			switch {
-			case len(n.child[0].typ.arg) > i && n.child[0].typ.arg[i].cat == interfaceT:
+			case arg.cat == interfaceT:
 				values = append(values, genValueInterface(c))
 			case isRecursiveType(c.typ, c.typ.rtype):
 				values = append(values, genValueRecursiveInterfacePtrValue(c))
@@ -1072,7 +1073,7 @@ func callBin(n *node) {
 				values = append(values, genFunctionWrapper(c))
 			case interfaceT:
 				values = append(values, genValueInterfaceValue(c))
-			case arrayT:
+			case arrayT, variadicT:
 				switch c.typ.val.cat {
 				case interfaceT:
 					values = append(values, genValueInterfaceArray(c))


### PR DESCRIPTION
Interface conversions were not handled in the variadic case in `call` and the unwrap was not handled in `callBin`. This fixes that.

Fixes #720