### PR TITLE
fix: avoid memory errors by handling frame indirections

### DIFF
--- a/_test/issue-735.go
+++ b/_test/issue-735.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+var optionsG map[string]string
+
+var roundG int = 30
+
+func strToInt(s string, defaultValue int) int {
+	n, err := strconv.ParseInt(s, 10, 0)
+	if err != nil {
+		return defaultValue
+	}
+	return int(n)
+}
+
+func main() {
+	optionsG := map[string]string{"round": "12", "b": "one"}
+	roundG = strToInt(optionsG["round"], 50)
+	fmt.Println(roundG)
+	fmt.Println(optionsG)
+}
+
+// Output:
+// 12
+// map[b:one round:12]

--- a/_test/time13.go
+++ b/_test/time13.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+var dummy = 1
+
+var t time.Time = time.Date(2007, time.November, 10, 23, 4, 5, 0, time.UTC)
+
+func main() {
+	t = time.Date(2009, time.November, 10, 23, 4, 5, 0, time.UTC)
+	fmt.Println(t.Clock())
+}
+
+// Output:
+// 23 4 5


### PR DESCRIPTION
In all situations where the results are set directly
into the frame, and not using a value helper, the right level of
indirections must be applied, otherwise we may end-up writing
in the wrong frame (the local one, instead of a caller or global).

Fixes #735.