### PR TITLE
fix: handle Func Value in genFunctionWrapper params

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -392,7 +392,7 @@ func TestEvalFunctionCallWithFunctionParam(t *testing.T) {
 	`)
 
 	v := eval(t, i, "Bar")
-	bar := v.Interface().(func(string, func(string)string) string)
+	bar := v.Interface().(func(string, func(string) string) string)
 
 	got := bar("hello ", func(s string) string {
 		return s + "world!"

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -385,6 +385,25 @@ func TestEvalChan(t *testing.T) {
 	})
 }
 
+func TestEvalFunctionCallWithFunctionParam(t *testing.T) {
+	i := interp.New(interp.Options{})
+	eval(t, i, `
+		func Bar(s string, fn func(string)string) string { return fn(s) }
+	`)
+
+	v := eval(t, i, "Bar")
+	bar := v.Interface().(func(string, func(string)string) string)
+
+	got := bar("hello ", func(s string) string {
+		return s + "world!"
+	})
+
+	want := "hello world!"
+	if got != want {
+		t.Errorf("unexpected result of function eval: got %q, want %q", got, want)
+	}
+}
+
 func TestEvalMissingSymbol(t *testing.T) {
 	defer func() {
 		r := recover()


### PR DESCRIPTION
`genFunctionWrapper` expects all function params to be of type `*node`. When calling from `Eval` this is not handled, so a node needs to be generated to call the given function.

I am unsure of the name `genFunctionNode`, suggestions on this are welcome.

Fixes #468