### PR TITLE
feature: sort vars by dependencies

### DIFF
--- a/_test/var12.go
+++ b/_test/var12.go
@@ -1,0 +1,24 @@
+package main
+
+var A = concat("hello", B)
+
+var B = concat(" ", C, "!")
+
+var C = D
+
+var D = "world"
+
+func concat(a ...string) string {
+	var s string
+	for _, ss := range a {
+		s += ss
+	}
+	return s
+}
+
+func main() {
+	println(A)
+}
+
+// Output:
+// hello world!

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -666,6 +666,15 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 			case token.VAR:
 				kind = varDecl
 			}
+
+			if kind == varDecl {
+				// In order to group all vars and consts under a single declaration
+				// find the correct anc.
+				if n := findNodeKind(anc.node.child, kind); n != nil {
+					st.push(n, nod)
+					break
+				}
+			}
 			st.push(addChild(&root, anc, pos, kind, aNop), nod)
 
 		case *ast.GoStmt:
@@ -853,7 +862,17 @@ func (interp *Interpreter) ast(src, name string) (string, *node, error) {
 		root = root.child[1].child[3]
 		root.anc = nil
 	}
+
 	return pkgName, root, err
+}
+
+func findNodeKind(ns []*node, k nkind) *node {
+	for _, c := range ns {
+		if c.kind == k {
+			return c
+		}
+	}
+	return nil
 }
 
 type astNode struct {


### PR DESCRIPTION
This implements dependency resolution ordering for vars at the global level. In the case of a var with a call expression, the order of execution is important. Perhaps this should be added to `cfg` and be at all levels?

@mvertes I would like your opinion on this before making it a full PR. I also think we can clean it up a bit, but that will be done before opening the PR.