### PR TITLE
fix: a const, non-const equality check must convert

### DIFF
--- a/_test/comp2.go
+++ b/_test/comp2.go
@@ -1,0 +1,14 @@
+package main
+
+type delta int32
+
+func main() {
+	a := delta(-1)
+
+	println(a != -1)
+	println(a == -1)
+}
+
+// Output:
+// false
+// true

--- a/internal/genop/genop.go
+++ b/internal/genop/genop.go
@@ -412,6 +412,8 @@ func {{$name}}(n *node) {
 	dest := genValueOutput(n, reflect.TypeOf(true))
 	c0, c1 := n.child[0], n.child[1]
 
+	{{- if or (eq $op.Name "==") (eq $op.Name "!=") }}
+
 	if c0.typ.cat == aliasT || c1.typ.cat == aliasT {
 		switch {
 		case c0.rval.IsValid():
@@ -432,7 +434,7 @@ func {{$name}}(n *node) {
 				dest := genValue(n)
 				n.exec = func(f *frame) bltn {
 					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 {{$op.Name}} i1)
 					return tnext
 				}
 			}
@@ -454,7 +456,7 @@ func {{$name}}(n *node) {
 				dest := genValue(n)
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 {{$op.Name}} i1)
 					return tnext
 				}
 			}
@@ -478,13 +480,14 @@ func {{$name}}(n *node) {
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
 					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 {{$op.Name}} i1)
 					return tnext
 				}
 			}
 		}
 		return
 	}
+	{{- end}}
 
 	switch t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf(); {
 	case isString(t0) || isString(t1):

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -732,6 +732,18 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				n.typ = c0.typ
 			case aEqual, aNotEqual:
 				n.typ = sc.getType("bool")
+				if isConstVal(c0) && !isConstVal(c1) || !isConstVal(c0) && isConstVal(c1) {
+					// if either node is a constant value, but the other is not, the constant
+					// must be converted into the non-constants type.
+					switch {
+					case isConstVal(c0):
+						convertConstantValue(c0)
+						c0.rval = c0.rval.Convert(c1.typ.TypeOf())
+					default:
+						convertConstantValue(c1)
+						c1.rval = c1.rval.Convert(c0.typ.TypeOf())
+					}
+				}
 				if n.child[0].sym == nilSym || n.child[1].sym == nilSym {
 					if n.action == aEqual {
 						n.gen = isNil

--- a/interp/op.go
+++ b/interp/op.go
@@ -2053,7 +2053,7 @@ func equal(n *node) {
 				dest := genValue(n)
 				n.exec = func(f *frame) bltn {
 					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 == i1)
 					return tnext
 				}
 			}
@@ -2075,7 +2075,7 @@ func equal(n *node) {
 				dest := genValue(n)
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 == i1)
 					return tnext
 				}
 			}
@@ -2099,7 +2099,7 @@ func equal(n *node) {
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
 					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
+					dest(f).SetBool(i0 == i1)
 					return tnext
 				}
 			}
@@ -2536,80 +2536,6 @@ func greater(n *node) {
 	dest := genValueOutput(n, reflect.TypeOf(true))
 	c0, c1 := n.child[0], n.child[1]
 
-	if c0.typ.cat == aliasT || c1.typ.cat == aliasT {
-		switch {
-		case c0.rval.IsValid():
-			i0 := c0.rval.Interface()
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		case c1.rval.IsValid():
-			i1 := c1.rval.Interface()
-			v0 := genValue(c0)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		}
-		return
-	}
-
 	switch t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf(); {
 	case isString(t0) || isString(t1):
 		switch {
@@ -2898,80 +2824,6 @@ func greaterEqual(n *node) {
 	tnext := getExec(n.tnext)
 	dest := genValueOutput(n, reflect.TypeOf(true))
 	c0, c1 := n.child[0], n.child[1]
-
-	if c0.typ.cat == aliasT || c1.typ.cat == aliasT {
-		switch {
-		case c0.rval.IsValid():
-			i0 := c0.rval.Interface()
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		case c1.rval.IsValid():
-			i1 := c1.rval.Interface()
-			v0 := genValue(c0)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		}
-		return
-	}
 
 	switch t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf(); {
 	case isString(t0) || isString(t1):
@@ -3262,80 +3114,6 @@ func lower(n *node) {
 	dest := genValueOutput(n, reflect.TypeOf(true))
 	c0, c1 := n.child[0], n.child[1]
 
-	if c0.typ.cat == aliasT || c1.typ.cat == aliasT {
-		switch {
-		case c0.rval.IsValid():
-			i0 := c0.rval.Interface()
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		case c1.rval.IsValid():
-			i1 := c1.rval.Interface()
-			v0 := genValue(c0)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		}
-		return
-	}
-
 	switch t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf(); {
 	case isString(t0) || isString(t1):
 		switch {
@@ -3624,80 +3402,6 @@ func lowerEqual(n *node) {
 	tnext := getExec(n.tnext)
 	dest := genValueOutput(n, reflect.TypeOf(true))
 	c0, c1 := n.child[0], n.child[1]
-
-	if c0.typ.cat == aliasT || c1.typ.cat == aliasT {
-		switch {
-		case c0.rval.IsValid():
-			i0 := c0.rval.Interface()
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		case c1.rval.IsValid():
-			i1 := c1.rval.Interface()
-			v0 := genValue(c0)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
-			if n.fnext != nil {
-				fnext := getExec(n.fnext)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					if i0 != i1 {
-						dest(f).SetBool(true)
-						return tnext
-					}
-					dest(f).SetBool(false)
-					return fnext
-				}
-			} else {
-				dest := genValue(n)
-				n.exec = func(f *frame) bltn {
-					i0 := v0(f).Interface()
-					i1 := v1(f).Interface()
-					dest(f).SetBool(i0 != i1)
-					return tnext
-				}
-			}
-		}
-		return
-	}
 
 	switch t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf(); {
 	case isString(t0) || isString(t1):


### PR DESCRIPTION
When checking equality with a const and non-const, the type of the const must be resolved. This is done as early as possible after the type check in the CFG. This also fixes a bug in the operations.

Fixes #744 