### PR TITLE
fix: avoid infinite loop when parsing recursive types

### DIFF
--- a/_test/struct53.go
+++ b/_test/struct53.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+type T1 struct {
+	P []*T
+}
+
+type T2 struct {
+	P2 *T
+}
+
+type T struct {
+	*T1
+	S1 *T
+}
+
+func main() {
+	fmt.Println(T2{})
+}
+
+// Output:
+// {<nil>}

--- a/interp/type.go
+++ b/interp/type.go
@@ -1385,6 +1385,8 @@ func hasRecursiveStruct(t *itype, defined map[string]*itype) bool {
 		if defined[typ.path+"/"+typ.name] != nil {
 			return true
 		}
+		defined[typ.path+"/"+typ.name] = typ
+
 		for _, f := range typ.field {
 			if hasRecursiveStruct(f.typ, defined) {
 				return true


### PR DESCRIPTION
Mark all visited types as such when walking down struct fields.

Fixes #750.
Updates #652.