### PR TITLE
fix: type assert when status is _

### DIFF
--- a/_test/interface45.go
+++ b/_test/interface45.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	var i interface{} = 1
+	var s struct{}
+	s, _ = i.(struct{})
+	fmt.Println(s)
+}
+
+// Output:
+// {}


### PR DESCRIPTION
If the status is _, there is no storage allocated in frame, and
the status assign operation should be skipped.

Fixes #761.