### PR TITLE
fix: avoid a panic in CFG in case of incomplete type

### DIFF
--- a/_test/const15.go
+++ b/_test/const15.go
@@ -1,0 +1,17 @@
+package main
+
+type T1 t1
+
+type t1 int8
+
+const (
+	P2 T1 = 2
+	P3 T1 = 3
+)
+
+func main() {
+	println(P3)
+}
+
+// Output:
+// 3

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -476,6 +476,9 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 							dest.typ = sc.fixType(src.typ)
 						}
 					}
+					if dest.typ.incomplete {
+						return
+					}
 					if dest.typ.sizedef {
 						dest.typ.size = arrayTypeLen(src)
 						dest.typ.rtype = nil


### PR DESCRIPTION
By returning early in case of incomplete type in CFG, we avoid
a panic, and let a chance to a new attempt after the missing
type has been parsed.

Fixes #763.