### PR TITLE
fix: execute global variables in the correct order

### DIFF
--- a/_test/var12.go
+++ b/_test/var12.go
@@ -1,0 +1,13 @@
+package main
+
+var (
+	a = b
+	b = "hello"
+)
+
+func main() {
+	println(a)
+}
+
+// Output:
+// hello

--- a/_test/var13.go
+++ b/_test/var13.go
@@ -1,0 +1,23 @@
+package main
+
+var (
+	a = concat("hello", b)
+	b = concat(" ", c, "!")
+	c = d
+	d = "world"
+)
+
+func concat(a ...string) string {
+	var s string
+	for _, ss := range a {
+		s += ss
+	}
+	return s
+}
+
+func main() {
+	println(a)
+}
+
+// Output:
+// hello world!

--- a/_test/var14.go
+++ b/_test/var14.go
@@ -1,0 +1,23 @@
+package main
+
+var (
+	a = concat("hello", b)
+	b = concat(" ", c, "!")
+	c = d
+	d = "world"
+)
+
+func concat(a ...string) string {
+	var s string
+	for _, ss := range a {
+		s += ss
+	}
+	return s
+}
+
+func main() {
+	println(a)
+}
+
+// Output:
+// hello world!

--- a/_test/var14.go
+++ b/_test/var14.go
@@ -1,22 +1,9 @@
 package main
 
-var (
-	a = concat("hello", b)
-	b = concat(" ", c, "!")
-	c = d
-	d = "world"
-)
-
-func concat(a ...string) string {
-	var s string
-	for _, ss := range a {
-		s += ss
-	}
-	return s
-}
+import "github.com/containous/yaegi/_test/vars"
 
 func main() {
-	println(a)
+	println(vars.A)
 }
 
 // Output:

--- a/_test/vars/first.go
+++ b/_test/vars/first.go
@@ -1,0 +1,1 @@
+package vars

--- a/_test/vars/first.go
+++ b/_test/vars/first.go
@@ -1,1 +1,14 @@
 package vars
+
+var (
+	A = concat("hello", B)
+	C = D
+)
+
+func concat(a ...string) string {
+	var s string
+	for _, ss := range a {
+		s += ss
+	}
+	return s
+}

--- a/_test/vars/second.go
+++ b/_test/vars/second.go
@@ -1,0 +1,1 @@
+package vars

--- a/_test/vars/second.go
+++ b/_test/vars/second.go
@@ -1,1 +1,6 @@
 package vars
+
+var (
+	B = concat(" ", C, "!")
+	D = "world"
+)

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -78,7 +78,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				if typ.isBinMethod {
 					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true, scope: sc}
 				}
-				if sc.sym[dest.ident] == nil {
+				if sc.sym[dest.ident] == nil || sc.sym[dest.ident].typ.incomplete {
 					sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
 				}
 				if n.anc.kind == constDecl {

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -79,7 +79,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 					typ = &itype{cat: valueT, rtype: typ.methodCallType(), isBinMethod: true, scope: sc}
 				}
 				if sc.sym[dest.ident] == nil || sc.sym[dest.ident].typ.incomplete {
-					sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val}
+					sc.sym[dest.ident] = &symbol{kind: varSym, global: true, index: sc.add(typ), typ: typ, rval: val, node: n}
 				}
 				if n.anc.kind == constDecl {
 					sc.sym[dest.ident].kind = constSym
@@ -112,7 +112,7 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				sym1, exists1 := sc.sym[asImportName]
 				sym2, exists2 := sc.sym[c.ident]
 				if !exists1 && !exists2 {
-					sc.sym[c.ident] = &symbol{index: sc.add(n.typ), kind: varSym, global: true, typ: n.typ}
+					sc.sym[c.ident] = &symbol{index: sc.add(n.typ), kind: varSym, global: true, typ: n.typ, node: n}
 					continue
 				}
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -405,6 +405,17 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 	// Execute node closures
 	interp.run(root, nil)
 
+	// Wire and execute global vars
+	vars := getVars(root)
+	if len(vars) > 0 {
+		varNode, err := genGlobalVarDecl(vars, interp.scopes[interp.Name])
+		if err != nil {
+			return res, err
+		}
+		setExec(varNode.start)
+		interp.run(varNode, nil)
+	}
+
 	for _, n := range initNodes {
 		interp.run(n, interp.frame)
 	}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -406,15 +406,11 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 	interp.run(root, nil)
 
 	// Wire and execute global vars
-	vars := getVars(root)
-	if len(vars) > 0 {
-		varNode, err := genGlobalVarDecl(vars, interp.scopes[interp.Name])
-		if err != nil {
-			return res, err
-		}
-		setExec(varNode.start)
-		interp.run(varNode, nil)
+	n, err := genGlobalVars([]*node{root}, interp.scopes[interp.Name])
+	if err != nil {
+		return res, err
 	}
+	interp.run(n, nil)
 
 	for _, n := range initNodes {
 		interp.run(n, interp.frame)

--- a/interp/run.go
+++ b/interp/run.go
@@ -84,6 +84,9 @@ func init() {
 }
 
 func (interp *Interpreter) run(n *node, cf *frame) {
+	if n == nil {
+		return
+	}
 	var f *frame
 	if cf == nil {
 		f = interp.frame

--- a/interp/src.go
+++ b/interp/src.go
@@ -133,18 +133,11 @@ func (interp *Interpreter) importSrc(rPath, path string) (string, error) {
 	}
 
 	// Wire and execute global vars
-	var vars []*node
-	for _, n := range rootNodes {
-		vars = append(vars, getVars(n)...)
+	n, err := genGlobalVars(rootNodes, interp.scopes[path])
+	if err != nil {
+		return "", err
 	}
-	if len(vars) > 0 {
-		varNode, err := genGlobalVarDecl(vars, interp.scopes[path])
-		if err != nil {
-			return "", err
-		}
-		setExec(varNode.start)
-		interp.run(varNode, nil)
-	}
+	interp.run(n, nil)
 
 	// Add main to list of functions to run, after all inits
 	if m := interp.main(); m != nil {

--- a/interp/src.go
+++ b/interp/src.go
@@ -132,6 +132,20 @@ func (interp *Interpreter) importSrc(rPath, path string) (string, error) {
 		interp.run(n, nil)
 	}
 
+	// Wire and execute global vars
+	var vars []*node
+	for _, n := range rootNodes {
+		vars = append(vars, getVars(n)...)
+	}
+	if len(vars) > 0 {
+		varNode, err := genGlobalVarDecl(vars, interp.scopes[path])
+		if err != nil {
+			return "", err
+		}
+		setExec(varNode.start)
+		interp.run(varNode, nil)
+	}
+
 	// Add main to list of functions to run, after all inits
 	if m := interp.main(); m != nil {
 		initNodes = append(initNodes, m)


### PR DESCRIPTION
To conform to the global spec, we need to reorder global variables and execute them before running init nodes.

Fixes #756
Fixes #742