### PR TITLE
fix: dont allow calling init

### DIFF
--- a/_test/init1.go
+++ b/_test/init1.go
@@ -1,0 +1,12 @@
+package main
+
+func init() {
+	println("here")
+}
+
+func main() {
+	init()
+}
+
+// Error:
+// _test/init1.go:8:2: undefined: init

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1153,11 +1153,11 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			n.types = sc.types
 			sc = sc.pop()
 			funcName := n.child[1].ident
-			if !isMethod(n) {
-				interp.scopes[pkgID].sym[funcName].index = -1 // to force value to n.val
-				interp.scopes[pkgID].sym[funcName].typ = n.typ
-				interp.scopes[pkgID].sym[funcName].kind = funcSym
-				interp.scopes[pkgID].sym[funcName].node = n
+			if sym := sc.sym[funcName]; !isMethod(n) && sym != nil {
+				sym.index = -1 // to force value to n.val
+				sym.typ = n.typ
+				sym.kind = funcSym
+				sym.node = n
 			}
 
 		case funcLit:
@@ -1170,6 +1170,10 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 
 		case identExpr:
 			if isKey(n) || isNewDefine(n, sc) {
+				break
+			}
+			if n.anc.kind == funcDecl && n.anc.child[1] == n {
+				// Dont process a function name identExpr.
 				break
 			}
 

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -45,6 +45,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "fun22.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
+			file.Name() == "init1.go" || // expect error
 			file.Name() == "io0.go" || // use random number
 			file.Name() == "op1.go" || // expect error
 			file.Name() == "op7.go" || // expect error


### PR DESCRIPTION
As per the Go spec, `init` functions never get declared and therefore can never be called.

Fixes #766 