### PR TITLE
fix: deal with untyped in type check

### DIFF
--- a/_test/math2.go
+++ b/_test/math2.go
@@ -1,0 +1,12 @@
+package main
+
+const c uint64 = 2
+
+func main() {
+	if c&(1<<(uint64(1))) > 0 {
+		println("yes")
+	}
+}
+
+// Output:
+// yes

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -699,6 +699,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			if !isShiftNode(n) && !isConstVal(c) && !c0.typ.equals(c1.typ) && t0 != nil && t1 != nil {
 				switch {
 				case isConstVal(c0) && isNumber(t1) || isConstVal(c1) && isNumber(t0): // const <-> numberic case
+				case isNumber(t0) && isNumber(t1) && (c0.typ.untyped || c1.typ.untyped):
 				case t0.Kind() == reflect.Uint8 && t1.Kind() == reflect.Int32 || t1.Kind() == reflect.Uint8 && t0.Kind() == reflect.Int32: // byte <-> rune case
 				case isInterface(c0.typ) && isInterface(c1.typ): // interface <-> interface case
 				default:


### PR DESCRIPTION
As we have both constVal and untyped, they both need to be checked in the binaryExpr type check. This is a stop gap fix. The  type checking needs to be looked at again.

Fixes #768 