### PR TITLE
interp: support yet another vendoring case

### DIFF
--- a/example/pkg/_pkg12/src/guthib.com/foo/main.go
+++ b/example/pkg/_pkg12/src/guthib.com/foo/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"guthib.com/foo/pkg"
+)
+
+func main() {
+	fmt.Printf("%s", pkg.NewSample()())
+}

--- a/example/pkg/_pkg12/src/guthib.com/foo/pkg/pkg.go
+++ b/example/pkg/_pkg12/src/guthib.com/foo/pkg/pkg.go
@@ -1,0 +1,17 @@
+package pkg
+
+import (
+	"fmt"
+
+	"guthib.com/bar"
+)
+
+func Here() string {
+	return "hello"
+}
+
+func NewSample() func() string {
+	return func() string {
+		return fmt.Sprintf("%s %s", bar.Bar(), Here())
+	}
+}

--- a/example/pkg/_pkg12/src/guthib.com/foo/vendor/guthib.com/bar/bar.go
+++ b/example/pkg/_pkg12/src/guthib.com/foo/vendor/guthib.com/bar/bar.go
@@ -1,0 +1,6 @@
+package bar
+
+// Bar is bar
+func Bar() string {
+	return "Yo"
+}

--- a/example/pkg/pkg_test.go
+++ b/example/pkg/pkg_test.go
@@ -83,6 +83,18 @@ func TestPackages(t *testing.T) {
 			expected: "Fromage",
 			evalFile: "./_pkg11/src/foo/foo.go",
 		},
+		{
+			desc:      "vendor dir is a sibling or an uncle",
+			goPath:    "./_pkg12/",
+			expected:  "Yo hello",
+			topImport: "guthib.com/foo/pkg",
+		},
+		{
+			desc:     "eval main with vendor as a sibling",
+			goPath:   "./_pkg12/",
+			expected: "Yo hello",
+			evalFile: "./_pkg12/src/guthib.com/foo/main.go",
+		},
 	}
 
 	for _, test := range testCases {
@@ -116,7 +128,7 @@ func TestPackages(t *testing.T) {
 				os.Stdout = pw
 
 				if _, err := i.Eval(string(data)); err != nil {
-					t.Fatal(err)
+					fatalStderr(t, "%v", err)
 				}
 
 				var buf bytes.Buffer
@@ -127,10 +139,10 @@ func TestPackages(t *testing.T) {
 				}()
 
 				if err := pw.Close(); err != nil {
-					t.Fatal(err)
+					fatalStderr(t, "%v", err)
 				}
 				if err := <-errC; err != nil {
-					t.Fatal(err)
+					fatalStderr(t, "%v", err)
 				}
 				msg = buf.String()
 			} else {
@@ -153,10 +165,15 @@ func TestPackages(t *testing.T) {
 			}
 
 			if msg != test.expected {
-				t.Errorf("Got %q, want %q", msg, test.expected)
+				fatalStderr(t, "Got %q, want %q", msg, test.expected)
 			}
 		})
 	}
+}
+
+func fatalStderr(t *testing.T, format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	t.FailNow()
 }
 
 func TestPackagesError(t *testing.T) {

--- a/example/pkg/pkg_test.go
+++ b/example/pkg/pkg_test.go
@@ -128,7 +128,7 @@ func TestPackages(t *testing.T) {
 				os.Stdout = pw
 
 				if _, err := i.Eval(string(data)); err != nil {
-					fatalStderr(t, "%v", err)
+					fatalStderrf(t, "%v", err)
 				}
 
 				var buf bytes.Buffer
@@ -139,10 +139,10 @@ func TestPackages(t *testing.T) {
 				}()
 
 				if err := pw.Close(); err != nil {
-					fatalStderr(t, "%v", err)
+					fatalStderrf(t, "%v", err)
 				}
 				if err := <-errC; err != nil {
-					fatalStderr(t, "%v", err)
+					fatalStderrf(t, "%v", err)
 				}
 				msg = buf.String()
 			} else {
@@ -165,13 +165,13 @@ func TestPackages(t *testing.T) {
 			}
 
 			if msg != test.expected {
-				fatalStderr(t, "Got %q, want %q", msg, test.expected)
+				fatalStderrf(t, "Got %q, want %q", msg, test.expected)
 			}
 		})
 	}
 }
 
-func fatalStderr(t *testing.T, format string, args ...interface{}) {
+func fatalStderrf(t *testing.T, format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, format+"\n", args...)
 	t.FailNow()
 }

--- a/interp/src_test.go
+++ b/interp/src_test.go
@@ -222,7 +222,9 @@ func Test_previousRoot(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			p := previousRoot(test.root)
+			// TODO(mpl): add tests for new algo.
+			// it's not too bad to not have them for now, since the tests in example run this code path too.
+			p, _ := previousRoot("vendor", test.root)
 
 			if p != test.expected {
 				t.Errorf("got: %s, want: %s", p, test.expected)

--- a/interp/src_test.go
+++ b/interp/src_test.go
@@ -224,7 +224,7 @@ func Test_previousRoot(t *testing.T) {
 
 			// TODO(mpl): add tests for new algo.
 			// it's not too bad to not have them for now, since the tests in example run this code path too.
-			p, _ := previousRoot("vendor", test.root)
+			p, _ := previousRoot(vendor, test.root)
 
 			if p != test.expected {
 				t.Errorf("got: %s, want: %s", p, test.expected)

--- a/interp/src_test.go
+++ b/interp/src_test.go
@@ -196,9 +196,10 @@ func Test_pkgDir(t *testing.T) {
 
 func Test_previousRoot(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		root     string
-		expected string
+		desc           string
+		root           string
+		rootPathSuffix string
+		expected       string
 	}{
 		{
 			desc:     "GOPATH",
@@ -215,6 +216,18 @@ func Test_previousRoot(t *testing.T) {
 			root:     "github.com/foo/pkg/vendor/guthib.com/containous/fromage/vendor/guthib.com/containous/fuu",
 			expected: "github.com/foo/pkg/vendor/guthib.com/containous/fromage",
 		},
+		{
+			desc:           "vendor is sibling",
+			root:           "github.com/foo/bar",
+			rootPathSuffix: "testdata/src/github.com/foo/bar",
+			expected:       "github.com/foo",
+		},
+		{
+			desc:           "vendor is uncle",
+			root:           "github.com/foo/bar/baz",
+			rootPathSuffix: "testdata/src/github.com/foo/bar/baz",
+			expected:       "github.com/foo",
+		},
 	}
 
 	for _, test := range testCases {
@@ -222,9 +235,20 @@ func Test_previousRoot(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			// TODO(mpl): add tests for new algo.
-			// it's not too bad to not have them for now, since the tests in example run this code path too.
-			p, _ := previousRoot(vendor, test.root)
+			var rootPath string
+			if test.rootPathSuffix != "" {
+				wd, err := os.Getwd()
+				if err != nil {
+					t.Fatal(err)
+				}
+				rootPath = filepath.Join(wd, test.rootPathSuffix)
+			} else {
+				rootPath = vendor
+			}
+			p, err := previousRoot(rootPath, test.root)
+			if err != nil {
+				t.Error(err)
+			}
 
 			if p != test.expected {
 				t.Errorf("got: %s, want: %s", p, test.expected)

--- a/interp/testdata/src/github.com/foo/bar/baz/baz.go
+++ b/interp/testdata/src/github.com/foo/bar/baz/baz.go
@@ -1,0 +1,1 @@
+package baz

--- a/interp/testdata/src/github.com/foo/vendor/whatever/whatever.go
+++ b/interp/testdata/src/github.com/foo/vendor/whatever/whatever.go
@@ -1,0 +1,1 @@
+package whatever


### PR DESCRIPTION
Namely, when the vendor dir is a sibling (or an uncle) relative to the
current pkg

Fixes #758
