### PR TITLE
fix: correct conversion to int in slice index expressions.

### DIFF
--- a/_test/issue-782.go
+++ b/_test/issue-782.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	from := uint32(2)
+	to := uint32(4)
+	b := a[from:to]
+	fmt.Print(b)
+}
+
+// Output:
+// [3 4]

--- a/interp/run.go
+++ b/interp/run.go
@@ -3025,7 +3025,7 @@ func slice(n *node) {
 	case 2:
 		n.exec = func(f *frame) bltn {
 			a := value0(f)
-			getFrame(f, l).data[i] = a.Slice(int(value1(f).Int()), a.Len())
+			getFrame(f, l).data[i] = a.Slice(int(vInt(value1(f))), a.Len())
 			return next
 		}
 	case 3:
@@ -3033,7 +3033,7 @@ func slice(n *node) {
 
 		n.exec = func(f *frame) bltn {
 			a := value0(f)
-			getFrame(f, l).data[i] = a.Slice(int(value1(f).Int()), int(value2(f).Int()))
+			getFrame(f, l).data[i] = a.Slice(int(vInt(value1(f))), int(vInt(value2(f))))
 			return next
 		}
 	case 4:
@@ -3042,7 +3042,7 @@ func slice(n *node) {
 
 		n.exec = func(f *frame) bltn {
 			a := value0(f)
-			getFrame(f, l).data[i] = a.Slice3(int(value1(f).Int()), int(value2(f).Int()), int(value3(f).Int()))
+			getFrame(f, l).data[i] = a.Slice3(int(vInt(value1(f))), int(vInt(value2(f))), int(vInt(value3(f))))
 			return next
 		}
 	}
@@ -3066,7 +3066,7 @@ func slice0(n *node) {
 		value1 := genValue(n.child[1])
 		n.exec = func(f *frame) bltn {
 			a := value0(f)
-			getFrame(f, l).data[i] = a.Slice(0, int(value1(f).Int()))
+			getFrame(f, l).data[i] = a.Slice(0, int(vInt(value1(f))))
 			return next
 		}
 	case 3:
@@ -3074,7 +3074,7 @@ func slice0(n *node) {
 		value2 := genValue(n.child[2])
 		n.exec = func(f *frame) bltn {
 			a := value0(f)
-			getFrame(f, l).data[i] = a.Slice3(0, int(value1(f).Int()), int(value2(f).Int()))
+			getFrame(f, l).data[i] = a.Slice3(0, int(vInt(value1(f))), int(vInt(value2(f))))
 			return next
 		}
 	}


### PR DESCRIPTION
One must use `vInt()` to handle all valid number cases.

Fixes #782.