### PR TITLE
fix: regression on range following #787

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -602,7 +602,9 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 					}
 					n.gen = nop
 					n.findex = -1
-					sc.sym[dest.ident].kind = constSym
+					if sym, _, ok := sc.lookup(dest.ident); ok {
+						sym.kind = constSym
+					}
 					if childPos(n) == len(n.anc.child)-1 {
 						sc.iota = 0
 					} else {

--- a/interp/value.go
+++ b/interp/value.go
@@ -162,7 +162,7 @@ func genValueRangeArray(n *node) func(*frame) reflect.Value {
 		return func(f *frame) reflect.Value {
 			return value(f).Elem()
 		}
-	case n.typ.val.cat == interfaceT:
+	case n.typ.val != nil && n.typ.val.cat == interfaceT:
 		return func(f *frame) reflect.Value {
 			val := value(f)
 			v := []valueInterface{}


### PR DESCRIPTION
This change fixes a nil pointer dereference regression introduced by
PR #787 which caused a traefik plugin to fail.