### PR TITLE
interp: change API of Eval

### DIFF
--- a/_test/eval0.go
+++ b/_test/eval0.go
@@ -9,13 +9,13 @@ import (
 func main() {
 	log.SetFlags(log.Lshortfile)
 	i := interp.New(interp.Options{})
-	if _, err := i.Eval(`func f() (int, int) { return 1, 2 }`); err != nil {
+	if _, err := i.EvalInc(`func f() (int, int) { return 1, 2 }`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := i.Eval(`a, b := f()`); err != nil {
+	if _, err := i.EvalInc(`a, b := f()`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := i.Eval(`println(a, b)`); err != nil {
+	if _, err := i.EvalInc(`println(a, b)`); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/_test/inception.go
+++ b/_test/inception.go
@@ -10,13 +10,13 @@ func main() {
 	log.SetFlags(log.Lshortfile)
 	i := interp.New(interp.Options{})
 	i.Use(interp.Symbols)
-	if _, err := i.Eval(`import "github.com/containous/yaegi/interp"`); err != nil {
+	if _, err := i.EvalInc(`import "github.com/containous/yaegi/interp"`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := i.Eval(`i := interp.New(interp.Options{})`); err != nil {
+	if _, err := i.EvalInc(`i := interp.New(interp.Options{})`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := i.Eval(`i.Eval("println(42)")`); err != nil {
+	if _, err := i.EvalInc(`i.EvalInc("println(42)")`); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/_test/interp.gi
+++ b/_test/interp.gi
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	i := interp.New(interp.Opt{})
-	i.Eval(`println("Hello")`)
+	i.EvalInc(`println("Hello")`)
 }
 
 // Output:

--- a/_test/interp2.gi
+++ b/_test/interp2.gi
@@ -7,9 +7,9 @@ import (
 func main() {
 	i := interp.New(interp.Opt{})
 	i.Use(interp.ExportValue, interp.ExportType)
-	i.Eval(`import "github.com/containous/yaegi/interp"`)
-	i.Eval(`i := interp.New(interp.Opt{})`)
-	i.Eval(`i.Eval("println(42)")`)
+	i.EvalInc(`import "github.com/containous/yaegi/interp"`)
+	i.EvalInc(`i := interp.New(interp.Opt{})`)
+	i.EvalInc(`i.Eval("println(42)")`)
 }
 
 // Output:

--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -162,8 +162,7 @@ func main() {
 		i.REPL(strings.NewReader(s), os.Stdout)
 	} else {
 		// Files not starting with "#!" are supposed to be pure Go, directly Evaled.
-		i.Name = args[0]
-		_, err := i.Eval(s)
+		_, err := i.Eval(s, args[0], false)
 		if err != nil {
 			fmt.Println(err)
 			if p, ok := err.(interp.Panic); ok {

--- a/example/closure/closure_test.go
+++ b/example/closure/closure_test.go
@@ -11,12 +11,12 @@ func TestFunctionCall(t *testing.T) {
 	i := interp.New(interp.Options{GoPath: "./_pkg"})
 	i.Use(stdlib.Symbols)
 
-	_, err := i.Eval(`import "foo/bar"`)
+	_, err := i.EvalInc(`import "foo/bar"`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fnv, err := i.Eval(`bar.NewSample()`)
+	fnv, err := i.EvalInc(`bar.NewSample()`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example/getfunc/getfunc_test.go
+++ b/example/getfunc/getfunc_test.go
@@ -12,11 +12,11 @@ func TestGetFunc(t *testing.T) {
 	i := interp.New(interp.Options{GoPath: "./_gopath/"})
 	i.Use(stdlib.Symbols)
 
-	if _, err := i.Eval(`import "github.com/foo/bar"`); err != nil {
+	if _, err := i.EvalInc(`import "github.com/foo/bar"`); err != nil {
 		t.Fatal(err)
 	}
 
-	val, err := i.Eval(`bar.NewFoo`)
+	val, err := i.EvalInc(`bar.NewFoo`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example/pkg/pkg_test.go
+++ b/example/pkg/pkg_test.go
@@ -111,8 +111,6 @@ func TestPackages(t *testing.T) {
 
 			var msg string
 			if test.evalFile != "" {
-				// setting i.Name as this is how it's actually done in cmd/yaegi
-				i.Name = test.evalFile
 				data, err := ioutil.ReadFile(test.evalFile)
 				if err != nil {
 					t.Fatal(err)
@@ -127,7 +125,7 @@ func TestPackages(t *testing.T) {
 				}
 				os.Stdout = pw
 
-				if _, err := i.Eval(string(data)); err != nil {
+				if _, err := i.Eval(string(data), test.evalFile, false); err != nil {
 					fatalStderrf(t, "%v", err)
 				}
 
@@ -151,10 +149,10 @@ func TestPackages(t *testing.T) {
 				if test.topImport != "" {
 					topImport = test.topImport
 				}
-				if _, err = i.Eval(fmt.Sprintf(`import "%s"`, topImport)); err != nil {
+				if _, err = i.EvalInc(fmt.Sprintf(`import "%s"`, topImport)); err != nil {
 					t.Fatal(err)
 				}
-				value, err := i.Eval(`pkg.NewSample()`)
+				value, err := i.EvalInc(`pkg.NewSample()`)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -185,7 +183,7 @@ func TestPackagesError(t *testing.T) {
 		{
 			desc:     "different packages in the same directory",
 			goPath:   "./_pkg9/",
-			expected: "1:21: import \"github.com/foo/pkg\" error: found packages pkg and pkgfalse in _pkg9/src/github.com/foo/pkg",
+			expected: interp.DefaultSourceName + ":1:21: import \"github.com/foo/pkg\" error: found packages pkg and pkgfalse in _pkg9/src/github.com/foo/pkg",
 		},
 	}
 
@@ -197,7 +195,7 @@ func TestPackagesError(t *testing.T) {
 			i.Use(stdlib.Symbols) // Use binary standard library
 
 			// Load pkg from sources
-			_, err := i.Eval(`import "github.com/foo/pkg"`)
+			_, err := i.EvalInc(`import "github.com/foo/pkg"`)
 			if err == nil {
 				t.Fatalf("got no error, want %q", test.expected)
 			}

--- a/interp/example_eval_test.go
+++ b/interp/example_eval_test.go
@@ -13,13 +13,13 @@ func Example_eval() {
 	i := interp.New(interp.Options{})
 
 	// Run some code: define a new function
-	_, err := i.Eval("func f(i int) int { return 2 * i }")
+	_, err := i.EvalInc("func f(i int) int { return 2 * i }")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Access the interpreted f function with Eval
-	v, err := i.Eval("f")
+	v, err := i.EvalInc("f")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -9,6 +9,8 @@ import (
 // variables and functions symbols at package level, prior to CFG.
 // All function bodies are skipped. GTA is necessary to handle out of
 // order declarations and multiple source files packages.
+// rpath is the relative path to the directory containing the source for pkgID.
+// TODO(mpl): clarify pkgID: package name VS package import path.
 func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error) {
 	sc := interp.initScopePkg(pkgID)
 	var err error
@@ -170,7 +172,6 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 				rcvrtype.method = append(rcvrtype.method, n)
 				n.child[0].child[0].lastChild().typ = rcvrtype
 			case ident == "init":
-				// TODO(mpl): use constant instead of hardcoded string?
 				// init functions do not get declared as per the Go spec.
 			default:
 				asImportName := filepath.Join(ident, baseName)
@@ -316,11 +317,11 @@ func (interp *Interpreter) gta(root *node, rpath, pkgID string) ([]*node, error)
 }
 
 // gtaRetry (re)applies gta until all global constants and types are defined.
-func (interp *Interpreter) gtaRetry(nodes []*node, rpath, pkgID string) error {
+func (interp *Interpreter) gtaRetry(nodes []*node, importPath string) error {
 	revisit := []*node{}
 	for {
 		for _, n := range nodes {
-			list, err := interp.gta(n, rpath, pkgID)
+			list, err := interp.gta(n, importPath, importPath)
 			if err != nil {
 				return err
 			}

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -111,12 +111,11 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			os.Stdout = w
 
 			i := interp.New(interp.Options{GoPath: build.Default.GOPATH})
-			i.Name = filePath
 			i.Use(stdlib.Symbols)
 			i.Use(interp.Symbols)
 			i.Use(unsafe.Symbols)
 
-			_, err = i.Eval(string(src))
+			_, err = i.Eval(string(src), filePath, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -252,10 +251,9 @@ func TestInterpErrorConsistency(t *testing.T) {
 			}
 
 			i := interp.New(interp.Options{GoPath: build.Default.GOPATH})
-			i.Name = filePath
 			i.Use(stdlib.Symbols)
 
-			_, errEval := i.Eval(string(src))
+			_, errEval := i.Eval(string(src), filePath, false)
 			if errEval == nil {
 				t.Fatal("An error is expected but got none.")
 			}

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -54,12 +54,11 @@ func runCheck(t *testing.T, p string) {
 	os.Stdout = w
 
 	i := interp.New(interp.Options{GoPath: build.Default.GOPATH})
-	i.Name = p
 	i.Use(interp.Symbols)
 	i.Use(stdlib.Symbols)
 	i.Use(unsafe.Symbols)
 
-	_, err = i.Eval(string(src))
+	_, err = i.Eval(string(src), p, false)
 	if errWanted {
 		if err == nil {
 			t.Fatalf("got nil error, want: %q", wanted)

--- a/interp/testdata/multi/731/sample1.go
+++ b/interp/testdata/multi/731/sample1.go
@@ -1,0 +1,7 @@
+package subpkg
+
+import "fmt"
+
+func PrintA() {
+	fmt.Println("A")
+}

--- a/interp/testdata/multi/731/sample2.go
+++ b/interp/testdata/multi/731/sample2.go
@@ -1,0 +1,7 @@
+package subpkg
+
+import "fmt"
+
+func PrintB() {
+	fmt.Println("B")
+}

--- a/interp/testdata/multi/731/sample3.go
+++ b/interp/testdata/multi/731/sample3.go
@@ -1,0 +1,8 @@
+package main
+
+import "subpkg"
+
+func main() {
+	subpkg.PrintA()
+	subpkg.PrintB()
+}

--- a/interp/type.go
+++ b/interp/type.go
@@ -446,7 +446,6 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 		sym, _, found := sc.lookup(n.ident)
 		if !found {
 			// retry with the filename, in case ident is a package name.
-			// TODO(mpl): try to move that into lookup instead?
 			baseName := filepath.Base(interp.fset.Position(n.pos).Filename)
 			ident := filepath.Join(n.ident, baseName)
 			sym, _, found = sc.lookup(ident)


### PR DESCRIPTION
The recent changes that added some redeclaration checks implicitly added more
strictness related to namespaces and scopes which, among other things, broke
some uses that "accidentally" used to work.

For example, given

```
const script1 = `
	import "fmt"

	// more code
`
const script2 = `
	import "fmt"

	// some other code
`
```

If one Evals script1, then script2, with the same interpreter, without
specifying any scope, as the two fragments would be considered part of the same
(.go file) scope by default, a redeclaration error would be triggered because
`import "fmt"` is seen twice.


A work-around would have been to specify (a different) `i.Name` before each Eval
call, so that each script is considered as coming from a different .go file, and
hence are respectively in different scopes with respect to imports.

That lead us to realize we had to make specifying things such as file-scope, and
"incremental mode" (aka REPL), more obvious in the context of an Eval call.
Hence the new signature for Eval:

```
func (interp *Interpreter) Eval(src, name string, incremental bool) (res reflect.Value, err error)
```

And to avoid confusion, the `Name` field of Interpreter is now non-exported,
since it would be redundant with the `name` argument of Eval.

As a convenience, the old Eval still exists, as:

```
func (interp *Interpreter) EvalInc(src string) (res reflect.Value, err error)
```

Finally, some related bugfixes, documention changes, and some refactoring have
been included. Notably, there is no "empty scope" anymore, i.e. `name` defaults
to "_.go" when it is not specified.

Fixes #731
Fixes #778