### PR TITLE
fix: interface call regression from #787

### DIFF
--- a/_test/interface46.go
+++ b/_test/interface46.go
@@ -1,0 +1,35 @@
+package main
+
+import "fmt"
+
+type I interface {
+	Foo() string
+}
+
+type Printer struct {
+	i I
+}
+
+func New(i I) *Printer {
+	return &Printer{
+		i: i,
+	}
+}
+
+func (p *Printer) Print() {
+	fmt.Println(p.i.Foo())
+}
+
+type T struct{}
+
+func (t *T) Foo() string {
+	return "test"
+}
+
+func main() {
+	g := New(&T{})
+	g.Print()
+}
+
+// Output:
+// test

--- a/interp/run.go
+++ b/interp/run.go
@@ -2116,8 +2116,6 @@ func doCompositeSparse(n *node, hasType bool) {
 		switch {
 		case c1.typ.cat == funcT:
 			values[field] = genFunctionWrapper(c1)
-		case c1.typ.cat == interfaceT:
-			values[field] = genValueInterfaceValue(c1)
 		case isArray(c1.typ) && c1.typ.val != nil && c1.typ.val.cat == interfaceT:
 			values[field] = genValueInterfaceArray(c1)
 		case isRecursiveType(n.typ.field[field].typ, n.typ.field[field].typ.rtype):


### PR DESCRIPTION
Fix #787 changes how interfaces are set on a struct (compositeSparce). This change however makes calling the interface panic. 

This PR reverts part of the change in #787 and adds a test to ensure it does not break again.