### PR TITLE
feat: add index and composite literal type checking

### DIFF
--- a/_test/math3.go
+++ b/_test/math3.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+func md5Crypt(password, salt, magic []byte) []byte {
+	d := md5.New()
+	d.Write(password)
+	d.Write(magic)
+	d.Write(salt)
+
+	d2 := md5.New()
+	d2.Write(password)
+	d2.Write(salt)
+
+	for i, mixin := 0, d2.Sum(nil); i < len(password); i++ {
+		d.Write([]byte{mixin[i%16]})
+	}
+
+	return d.Sum(nil)
+}
+
+func main() {
+	b := md5Crypt([]byte("1"), []byte("2"), []byte("3"))
+
+	fmt.Println(b)
+}
+
+// Output:
+// [187 141 73 89 101 229 33 106 226 63 117 234 117 149 230 21]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -946,19 +946,25 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 		case compositeLitExpr:
 			wireChild(n)
 
+			child := n.child
+			if n.nleft > 0 {
+				child = child[1:]
+			}
+
 			switch n.typ.cat {
 			case aliasT, ptrT:
 			case arrayT:
-				child := n.child
-				if n.nleft > 0 {
-					child = child[1:]
-				}
 				typ := n.typ.val
 				if typ.cat == ptrT || typ.cat == aliasT { // match compositeGenerator
 					typ = typ.val
 				}
 				err = check.arrayLitExpr(child, typ, n.typ.size)
 			case mapT:
+				typ := n.typ.val
+				if typ.cat == ptrT || typ.cat == aliasT { // match compositeGenerator
+					typ = typ.val
+				}
+				err = check.mapLitExpr(child, n.typ.key, typ)
 			case structT:
 				switch {
 				case len(n.child) == 0:

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -271,7 +271,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 				case binaryExpr, unaryExpr, compositeLitExpr:
 					// Do not attempt to propagate composite type to operator expressions,
 					// it breaks constant folding.
-				case keyValueExpr, typeAssertExpr:
+				case keyValueExpr, typeAssertExpr, indexExpr:
 					c.typ = n.typ
 				default:
 					if c.ident == nilIdent {

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -946,7 +946,7 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 		case compositeLitExpr:
 			wireChild(n)
 
-			underlying := func (t *itype) *itype {
+			underlying := func(t *itype) *itype {
 				for {
 					switch t.cat {
 					case ptrT, aliasT:
@@ -971,9 +971,14 @@ func (interp *Interpreter) cfg(root *node, pkgID string) ([]*node, error) {
 			case structT:
 				err = check.structLitExpr(child, n.typ)
 			case valueT:
-				switch k := n.typ.rtype.Kind(); k {
+				rtype := n.typ.rtype
+				switch rtype.Kind() {
 				case reflect.Struct:
+					err = check.structBinLitExpr(child, rtype)
 				case reflect.Map:
+					ktyp := &itype{cat: valueT, rtype: rtype.Key()}
+					vtyp := &itype{cat: valueT, rtype: rtype.Elem()}
+					err = check.mapLitExpr(child, ktyp, vtyp)
 				}
 			}
 			if err != nil {

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -330,6 +330,24 @@ func TestEvalCompositeMap(t *testing.T) {
 	})
 }
 
+func TestEvalCompositeStruct(t *testing.T) {
+	i := interp.New(interp.Options{})
+	runTests(t, i, []testCase{
+		{src: `a := struct{A,B,C int}{}`, res: "{0 0 0}"},
+		{src: `a := struct{A,B,C int}{1,2,3}`, res: "{1 2 3}"},
+		{src: `a := struct{A,B,C int}{1,2.2,3}`, err: "1:53: 11/5 truncated to int"},
+		{src: `a := struct{A,B,C int}{1,2}`, err: "1:53: too few values in struct literal"},
+		{src: `a := struct{A,B,C int}{1,2,3,4}`, err: "1:57: too many values in struct literal"},
+		{src: `a := struct{A,B,C int}{1,B:2,3}`, err: "1:53: mixture of field:value and value elements in struct literal"},
+		{src: `a := struct{A,B,C int}{A:1,B:2,C:3}`, res: "{1 2 3}"},
+		{src: `a := struct{A,B,C int}{B:2}`, res: "{0 2 0}"},
+		{src: `a := struct{A,B,C int}{A:1,D:2,C:3}`, err: "1:55: unknown field D in struct literal"},
+		{src: `a := struct{A,B,C int}{A:1,A:2,C:3}`, err: "1:55: duplicate field name A in struct literal"},
+		{src: `a := struct{A,B,C int}{A:1,B:2.2,C:3}`, err: "1:57: 11/5 truncated to int"},
+		{src: `a := struct{A,B,C int}{A:1,2,C:3}`, err: "1:55: mixture of field:value and value elements in struct literal"},
+	})
+}
+
 func TestEvalUnary(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -311,6 +311,11 @@ func TestEvalCompositeArray(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{
 		{src: "a := []int{1, 2, 7: 20, 30}", res: "[1 2 0 0 0 0 0 20 30]"},
+		{src: `a := []int{1, 1.2}`, err: "1:42: 6/5 truncated to int"},
+		{src: `a := []int{0:1, 0:1}`, err: "1:46: duplicate index 0 in array or slice literal"},
+		{src: `a := []int{1.1:1, 1.2:"test"}`, err: "1:39: index float64 must be integer constant"},
+		{src: `a := [2]int{1, 1.2}`, err: "1:43: 6/5 truncated to int"},
+		{src: `a := [1]int{1, 2}`, err: "1:43: index 1 is out of bounds (>= 1)"},
 	})
 }
 

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -319,6 +319,17 @@ func TestEvalCompositeArray(t *testing.T) {
 	})
 }
 
+func TestEvalCompositeMap(t *testing.T) {
+	i := interp.New(interp.Options{})
+	runTests(t, i, []testCase{
+		{src: `a := map[string]int{"one":1, "two":2}`, res: "map[one:1 two:2]"},
+		{src: `a := map[string]int{1:1, 2:2}`, err: "1:48: cannot convert 1 to string"},
+		{src: `a := map[string]int{"one":1, "two":2.2}`, err: "1:63: 11/5 truncated to int"},
+		{src: `a := map[string]int{1, "two":2}`, err: "1:48: missing key in map literal"},
+		{src: `a := map[string]int{"one":1, "one":2}`, err: "1:57: duplicate key one in map literal"},
+	})
+}
+
 func TestEvalUnary(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/run.go
+++ b/interp/run.go
@@ -1315,7 +1315,6 @@ func getIndexMap(n *node) {
 	z := reflect.New(n.child[0].typ.frameType().Elem()).Elem()
 
 	if n.child[1].rval.IsValid() { // constant map index
-		convertConstantValue(n.child[1])
 		mi := n.child[1].rval
 
 		switch {
@@ -1409,7 +1408,6 @@ func getIndexMap2(n *node) {
 		return
 	}
 	if n.child[1].rval.IsValid() { // constant map index
-		convertConstantValue(n.child[1])
 		mi := n.child[1].rval
 		switch {
 		case !doValue:

--- a/interp/value.go
+++ b/interp/value.go
@@ -334,10 +334,6 @@ func vInt(v reflect.Value) (i int64) {
 	case reflect.Complex64, reflect.Complex128:
 		i = int64(real(v.Complex()))
 	}
-	if v.Type().Implements(constVal) {
-		c := v.Interface().(constant.Value)
-		i, _ = constant.Int64Val(constant.ToInt(c))
-	}
 	return
 }
 
@@ -351,11 +347,6 @@ func vUint(v reflect.Value) (i uint64) {
 		i = uint64(v.Float())
 	case reflect.Complex64, reflect.Complex128:
 		i = uint64(real(v.Complex()))
-	}
-	if v.Type().Implements(constVal) {
-		c := v.Interface().(constant.Value)
-		iv, _ := constant.Int64Val(constant.ToInt(c))
-		i = uint64(iv)
 	}
 	return
 }
@@ -371,13 +362,6 @@ func vComplex(v reflect.Value) (c complex128) {
 	case reflect.Complex64, reflect.Complex128:
 		c = v.Complex()
 	}
-	if v.Type().Implements(constVal) {
-		con := v.Interface().(constant.Value)
-		con = constant.ToComplex(con)
-		rel, _ := constant.Float64Val(constant.Real(con))
-		img, _ := constant.Float64Val(constant.Imag(con))
-		c = complex(rel, img)
-	}
 	return
 }
 
@@ -391,10 +375,6 @@ func vFloat(v reflect.Value) (i float64) {
 		i = v.Float()
 	case reflect.Complex64, reflect.Complex128:
 		i = real(v.Complex())
-	}
-	if v.Type().Implements(constVal) {
-		c := v.Interface().(constant.Value)
-		i, _ = constant.Float64Val(constant.ToFloat(c))
 	}
 	return
 }


### PR DESCRIPTION
This adds type checking to both `IndexExpr` and `CompositeLitExpr` as well as handling any required constant type conversion.

This includes a change to the type propagation to the children of a composite literal. Previously in most cases the composite literal type was propagated to its children. This does not work with type checking as the actual child type is needed.