### PR TITLE
fix: composite literal type check

### DIFF
--- a/_test/struct55.go
+++ b/_test/struct55.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+type Logger struct {
+	m []*log.Logger
+}
+
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.m[0].Printf(format, args...)
+}
+
+func main() {
+	l := &Logger{m: []*log.Logger{log.New(os.Stdout, "", log.Lmsgprefix)}}
+	l.Infof("test %s", "test")
+}
+
+// Output:
+// test test


### PR DESCRIPTION
In the case of a pointer or alias composite literal expression, `compositeGenerator` changes the type to remove the pointer or alias. This causes a nested composite literal to have the wrong type.

Instead of changing the node type, the removal of the pointer or alias is moved to the runtime, allowing the node type to remain unchanged. This fixes potential issues in the type checking.