### PR TITLE
feature: improve handling of interrupt signal in REPL

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -615,11 +615,13 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 	}()
 
 	for {
+		var line string
+
 		select {
 		case <-end:
 			cancel()
 			return
-		case line := <-lines:
+		case line = <-lines:
 			src += line + "\n"
 		}
 
@@ -627,7 +629,7 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 		if err != nil {
 			switch e := err.(type) {
 			case scanner.ErrorList:
-				if len(e) == 0 || ignoreScannerError(e[0], s.Text()) {
+				if len(e) == 0 || ignoreScannerError(e[0], line) {
 					continue
 				}
 				fmt.Fprintln(out, e[0])

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -504,7 +504,7 @@ func (interp *Interpreter) EvalWithContext(ctx context.Context, src string) (ref
 	select {
 	case <-ctx.Done():
 		interp.stop()
-		return reflect.Value{}, ctx.Err()
+		v, err = reflect.Value{}, ctx.Err()
 	case <-done:
 	}
 	return v, err

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -504,7 +504,7 @@ func (interp *Interpreter) EvalWithContext(ctx context.Context, src string) (ref
 	select {
 	case <-ctx.Done():
 		interp.stop()
-		v, err = reflect.Value{}, ctx.Err()
+		return reflect.Value{}, ctx.Err()
 	case <-done:
 	}
 	return v, err

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -598,12 +598,25 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 		// TODO(mpl): log s.Err() if not nil?
 	}()
 
+	go func() {
+		for {
+			select {
+			case <-sig:
+				// Catch interrupt while EvalWithContext is running.
+				cancel()
+			case <-end:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-end:
 			cancel()
 			return
 		case <-sig:
+			// Catch interrupt while input scanning.
 			cancel()
 		case line := <-lines:
 			src += line + "\n"

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -591,6 +591,7 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 	src := ""                      // source string to evaluate
 
 	signal.Notify(sig, os.Interrupt)
+	defer signal.Stop(sig)
 	prompt(v)
 
 	go func() {
@@ -605,8 +606,8 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 		for {
 			select {
 			case <-sig:
-				// Catch interrupt while EvalWithContext is running.
 				cancel()
+				lines <- ""
 			case <-end:
 				return
 			}
@@ -618,9 +619,6 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 		case <-end:
 			cancel()
 			return
-		case <-sig:
-			// Catch interrupt while input scanning.
-			cancel()
 		case line := <-lines:
 			src += line + "\n"
 		}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -486,7 +486,10 @@ func (interp *Interpreter) eval(src, name string, inc bool) (res reflect.Value, 
 
 // EvalWithContext evaluates Go code represented as a string. It returns
 // a map on current interpreted package exported symbols.
-func (interp *Interpreter) EvalWithContext(ctx context.Context, src string) (v reflect.Value, err error) {
+func (interp *Interpreter) EvalWithContext(ctx context.Context, src string) (reflect.Value, error) {
+	var v reflect.Value
+	var err error
+
 	interp.mutex.Lock()
 	interp.done = make(chan struct{})
 	interp.cancelChan = !interp.opt.fastChan
@@ -503,8 +506,8 @@ func (interp *Interpreter) EvalWithContext(ctx context.Context, src string) (v r
 		interp.stop()
 		return reflect.Value{}, ctx.Err()
 	case <-done:
-		return v, err
 	}
+	return v, err
 }
 
 // stop sends a semaphore to all running frames and closes the chan
@@ -591,10 +594,10 @@ func (interp *Interpreter) REPL(in io.Reader, out io.Writer) {
 	prompt(v)
 
 	go func() {
+		defer close(end)
 		for s.Scan() {
 			lines <- s.Text()
 		}
-		close(end)
 		// TODO(mpl): log s.Err() if not nil?
 	}()
 


### PR DESCRIPTION
The input scanning is now performed in a sub goroutine and
the interrupt is listened in another goroutine, either to cancel Eval
or to cancel the current line scan.
Entering a '\n' after a 'Ctrl-C` to get the prompt is
not necessary anymore.