### PR TITLE
fix: check array size symbol kind

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -326,6 +326,7 @@ func TestEvalComparison(t *testing.T) {
 
 func TestEvalCompositeArray(t *testing.T) {
 	i := interp.New(interp.Options{})
+	eval(t, i, `const l = 10`)
 	runTests(t, i, []testCase{
 		{src: "a := []int{1, 2, 7: 20, 30}", res: "[1 2 0 0 0 0 0 20 30]"},
 		{src: `a := []int{1, 1.2}`, err: "1:42: 6/5 truncated to int"},
@@ -333,6 +334,8 @@ func TestEvalCompositeArray(t *testing.T) {
 		{src: `a := []int{1.1:1, 1.2:"test"}`, err: "1:39: index float64 must be integer constant"},
 		{src: `a := [2]int{1, 1.2}`, err: "1:43: 6/5 truncated to int"},
 		{src: `a := [1]int{1, 2}`, err: "1:43: index 1 is out of bounds (>= 1)"},
+		{src: `b := [l]int{1, 2}`, res: "[1 2 0 0 0 0 0 0 0 0]"},
+		{src: `i := 10; a := [i]int{1, 2}`, err: "1:43: non-constant array bound \"i\""},
 	})
 }
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -182,6 +182,9 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				t.size = arrayTypeLen(n.anc)
 			default:
 				if sym, _, ok := sc.lookup(n.child[0].ident); ok {
+					if sym.kind != constSym {
+						return nil, n.child[0].cfgErrorf("non-constant array bound %q", n.child[0].ident)
+					}
 					// Resolve symbol to get size value
 					if sym.typ != nil && sym.typ.cat == intT {
 						if v, ok := sym.rval.Interface().(int); ok {


### PR DESCRIPTION
When determining the size of an array and a symbol is found, the symbol must be a const for the type to be valid. 

While it makes sense for this check to be done in type checking, the type can be determined by GTA which would then fail. For now this check is done when getting the node type.

Fixes #825