### PR TITLE
interp: enable declaration errors detection at parsing time

### DIFF
--- a/_test/redeclaration-global5.go
+++ b/_test/redeclaration-global5.go
@@ -12,4 +12,5 @@ func main() {
 }
 
 // Error:
-// ../_test/redeclaration-global5.go:5:1: time redeclared in this block
+// ../_test/redeclaration-global5.go:5:6: time redeclared in this block
+//	previous declaration at ../_test/redeclaration-global5.go:3:5

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -349,7 +349,7 @@ func (interp *Interpreter) firstToken(src string) token.Token {
 // interpreter's FileSet.
 func (interp *Interpreter) ast(src, name string, inc bool) (string, *node, error) {
 	var inFunc bool
-	var mode parser.Mode
+	mode := parser.DeclarationErrors
 
 	// Allow incremental parsing of declarations or statements, by inserting
 	// them in a pseudo file package or function. Those statements or

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -386,12 +386,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				return false
 			}
 
-			if _, exists := sc.sym[typeName]; exists {
-				// TODO(mpl): find the exact location of the previous declaration
-				err = n.cfgErrorf("%s redeclared in this block", typeName)
-				return false
-			}
-
 			if n.child[1].kind == identExpr {
 				n.typ = &itype{cat: aliasT, val: typ, name: typeName}
 			} else {
@@ -1776,18 +1770,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					// Global object allocation is already performed in GTA.
 					index = sc.sym[c.ident].index
 				} else {
-					if sym, exists := sc.sym[c.ident]; exists {
-						if sym.typ.node != nil &&
-							sym.typ.node.anc != nil {
-							// for non-predeclared identifiers (struct, map, etc)
-							prevDecl := n.interp.fset.Position(sym.typ.node.anc.pos)
-							err = n.cfgErrorf("%s redeclared in this block\n\tprevious declaration at %v", c.ident, prevDecl)
-							return
-						}
-						// for predeclared identifiers (int, string, etc)
-						err = n.cfgErrorf("%s redeclared in this block", c.ident)
-						return
-					}
 					index = sc.add(n.typ)
 					sc.sym[c.ident] = &symbol{index: index, kind: varSym, typ: n.typ}
 				}

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -790,7 +790,7 @@ func TestMultiEvalNoName(t *testing.T) {
 		_, err = i.Eval(string(data))
 		if k == 1 {
 			expectedErr := fmt.Errorf("3:8: fmt/%s redeclared in this block", interp.DefaultSourceName)
-			if err.Error() != expectedErr.Error() {
+			if err == nil || err.Error() != expectedErr.Error() {
 				t.Fatalf("unexpected result; wanted error %v, got %v", expectedErr, err)
 			}
 			return


### PR DESCRIPTION
The Go parser is able to detect some (but not all) (re-)declaration errors,
if the DeclarationErrors flag is enabled, which was not done so far.

This PR therefore enables that flag, which allows the removal of some of
the now unneeded code that was recently added to support redeclarations.

Fixes #811