### PR TITLE
feat: configure stdin, stdout and stderr per interpreter

### DIFF
--- a/_test/eval0.go
+++ b/_test/eval0.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/containous/yaegi/interp"
 )
 
 func main() {
 	log.SetFlags(log.Lshortfile)
-	i := interp.New(interp.Options{})
+	i := interp.New(interp.Options{Stdout: os.Stdout})
 	if _, err := i.Eval(`func f() (int, int) { return 1, 2 }`); err != nil {
 		log.Fatal(err)
 	}

--- a/_test/inception.go
+++ b/_test/inception.go
@@ -20,6 +20,3 @@ func main() {
 		log.Fatal(err)
 	}
 }
-
-// Output:
-// 42

--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -56,14 +56,14 @@ func run(arg []string) error {
 	}
 
 	if cmd != "" {
-		i.REPL(strings.NewReader(cmd), os.Stderr)
+		_, err = i.Eval(cmd)
 	}
 
 	if len(args) == 0 {
 		if interactive || cmd == "" {
-			i.REPL(os.Stdin, os.Stdout)
+			_, err = i.REPL()
 		}
-		return nil
+		return err
 	}
 
 	// Skip first os arg to set command line as expected by interpreted main
@@ -85,9 +85,9 @@ func run(arg []string) error {
 	}
 
 	if interactive {
-		i.REPL(os.Stdin, os.Stdout)
+		_, err = i.REPL()
 	}
-	return nil
+	return err
 }
 
 func isPackageName(path string) bool {
@@ -116,7 +116,7 @@ func runFile(i *interp.Interpreter, path string) error {
 	if s := string(b); strings.HasPrefix(s, "#!") {
 		// Allow executable go scripts, Have the same behavior as in interactive mode.
 		s = strings.Replace(s, "#!", "//", 1)
-		i.REPL(strings.NewReader(s), os.Stdout)
+		_, err = i.Eval(s)
 	} else {
 		// Files not starting with "#!" are supposed to be pure Go, directly Evaled.
 		_, err := i.EvalPath(path)
@@ -127,5 +127,5 @@ func runFile(i *interp.Interpreter, path string) error {
 			}
 		}
 	}
-	return nil
+	return err
 }

--- a/cmd/yaegi/yaegi_test.go
+++ b/cmd/yaegi/yaegi_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -108,7 +110,7 @@ func TestYaegiCmdCancel(t *testing.T) {
 			continue
 		}
 
-		if errBuf.String() != "context canceled\n" {
+		if strings.TrimSuffix(errBuf.String(), "\n") != context.Canceled.Error() {
 			t.Errorf("unexpected error: %q", &errBuf)
 		}
 	}

--- a/cmd/yaegi/yaegi_test.go
+++ b/cmd/yaegi/yaegi_test.go
@@ -108,8 +108,8 @@ func TestYaegiCmdCancel(t *testing.T) {
 			continue
 		}
 
-		if outBuf.String() != "context canceled\n" {
-			t.Errorf("unexpected output: %q", &outBuf)
+		if errBuf.String() != "context canceled\n" {
+			t.Errorf("unexpected error: %q", &errBuf)
 		}
 	}
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -581,22 +581,22 @@ func fixStdio(interp *Interpreter) {
 	if p = interp.binPkg["log"]; p != nil {
 		l := log.New(stderr, "", log.LstdFlags)
 		// Restrict Fatal symbols to panic instead of exit.
-		p["Fatal"] = reflect.ValueOf(func(a ...interface{}) { l.Panic(a...) })
-		p["Fatalf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Panicf(f, a...) })
-		p["Fatalln"] = reflect.ValueOf(func(a ...interface{}) { l.Panicln(a...) })
+		p["Fatal"] = reflect.ValueOf(l.Panic)
+		p["Fatalf"] = reflect.ValueOf(l.Panicf)
+		p["Fatalln"] = reflect.ValueOf(l.Panicln)
 
 		p["Flags"] = reflect.ValueOf(l.Flags)
 		p["Output"] = reflect.ValueOf(l.Output)
 		p["Panic"] = reflect.ValueOf(l.Panic)
-		p["Panicf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Panicf(f, a...) })
-		p["Panicln"] = reflect.ValueOf(func(a ...interface{}) { l.Panicln(a...) })
+		p["Panicf"] = reflect.ValueOf(l.Panicf)
+		p["Panicln"] = reflect.ValueOf(l.Panicln)
 		p["Prefix"] = reflect.ValueOf(l.Prefix)
 		p["Print"] = reflect.ValueOf(l.Print)
-		p["Printf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Printf(f, a...) })
+		p["Printf"] = reflect.ValueOf(l.Printf)
 		p["Println"] = reflect.ValueOf(l.Println)
-		p["SetFlags"] = reflect.ValueOf(func(f int) { l.SetFlags(f) })
-		p["SetOutput"] = reflect.ValueOf(func(w io.Writer) { l.SetOutput(w) })
-		p["SetPrefix"] = reflect.ValueOf(func(s string) { l.SetPrefix(s) })
+		p["SetFlags"] = reflect.ValueOf(l.SetFlags)
+		p["SetOutput"] = reflect.ValueOf(l.SetOutput)
+		p["SetPrefix"] = reflect.ValueOf(l.SetPrefix)
 		p["Writer"] = reflect.ValueOf(l.Writer)
 	}
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -722,7 +722,7 @@ func (interp *Interpreter) REPL() (reflect.Value, error) {
 				if len(e) > 0 && ignoreScannerError(e[0], line) {
 					continue
 				}
-				fmt.Fprintln(errs, e[0])
+				fmt.Fprintln(errs, strings.TrimPrefix(e[0].Error(), DefaultSourceName+":"))
 			case Panic:
 				fmt.Fprintln(errs, e.Value)
 				fmt.Fprintln(errs, string(e.Stack))

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -216,7 +216,7 @@ type Options struct {
 	GoPath string
 	// BuildTags sets build constraints for the interpreter.
 	BuildTags []string
-	// Standard input, ouput and error streams.
+	// Standard input, output and error streams.
 	Stdin          io.Reader
 	Stdout, Stderr io.Writer
 }
@@ -584,19 +584,20 @@ func fixStdio(interp *Interpreter) {
 		p["Fatal"] = reflect.ValueOf(func(a ...interface{}) { l.Panic(a...) })
 		p["Fatalf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Panicf(f, a...) })
 		p["Fatalln"] = reflect.ValueOf(func(a ...interface{}) { l.Panicln(a...) })
-		p["Flags"] = reflect.ValueOf(func() int { return l.Flags() })
-		p["Output"] = reflect.ValueOf(func(c int, s string) error { return l.Output(c, s) })
-		p["Panic"] = reflect.ValueOf(func(a ...interface{}) { l.Panic(a...) })
+
+		p["Flags"] = reflect.ValueOf(l.Flags)
+		p["Output"] = reflect.ValueOf(l.Output)
+		p["Panic"] = reflect.ValueOf(l.Panic)
 		p["Panicf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Panicf(f, a...) })
 		p["Panicln"] = reflect.ValueOf(func(a ...interface{}) { l.Panicln(a...) })
-		p["Prefix"] = reflect.ValueOf(func() string { return l.Prefix() })
-		p["Print"] = reflect.ValueOf(func(a ...interface{}) { l.Print(a...) })
+		p["Prefix"] = reflect.ValueOf(l.Prefix)
+		p["Print"] = reflect.ValueOf(l.Print)
 		p["Printf"] = reflect.ValueOf(func(f string, a ...interface{}) { l.Printf(f, a...) })
-		p["Println"] = reflect.ValueOf(func(a ...interface{}) { l.Println(a...) })
+		p["Println"] = reflect.ValueOf(l.Println)
 		p["SetFlags"] = reflect.ValueOf(func(f int) { l.SetFlags(f) })
 		p["SetOutput"] = reflect.ValueOf(func(w io.Writer) { l.SetOutput(w) })
 		p["SetPrefix"] = reflect.ValueOf(func(s string) { l.SetPrefix(s) })
-		p["Writer"] = reflect.ValueOf(func() io.Writer { return l.Writer() })
+		p["Writer"] = reflect.ValueOf(l.Writer)
 	}
 
 	if p = interp.binPkg["os"]; p != nil {

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -138,7 +138,10 @@ func TestEvalStdout(t *testing.T) {
 	var out, err bytes.Buffer
 	i := interp.New(interp.Options{Stdout: &out, Stderr: &err})
 	i.Use(stdlib.Symbols)
-	i.Eval(`import "fmt"; func main() { fmt.Println("hello") }`)
+	_, e := i.Eval(`import "fmt"; func main() { fmt.Println("hello") }`)
+	if e != nil {
+		t.Fatal(e)
+	}
 	wanted := "hello\n"
 	if res := out.String(); res != wanted {
 		t.Fatalf("got %v, want %v", res, wanted)
@@ -954,7 +957,7 @@ func TestEvalScanner(t *testing.T) {
 		}()
 
 		go func() {
-			i.REPL()
+			_, _ = i.REPL()
 		}()
 		for k, v := range test.src {
 			if _, err := pout.Write([]byte(v + "\n")); err != nil {

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -1,6 +1,7 @@
 package interp_test
 
 import (
+	"bytes"
 	"go/build"
 	"go/parser"
 	"go/token"
@@ -43,15 +44,16 @@ func runCheck(t *testing.T, p string) {
 	wanted = strings.TrimSpace(wanted)
 
 	// catch stdout
-	backupStdout := os.Stdout
-	defer func() { os.Stdout = backupStdout }()
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	//backupStdout := os.Stdout
+	//defer func() { os.Stdout = backupStdout }()
+	//r, w, _ := os.Pipe()
+	//os.Stdout = w
 
 	if goPath == "" {
 		goPath = build.Default.GOPATH
 	}
-	i := interp.New(interp.Options{GoPath: goPath})
+	var stdout, stderr bytes.Buffer
+	i := interp.New(interp.Options{GoPath: goPath, Stdout: &stdout, Stderr: &stderr})
 	i.Use(interp.Symbols)
 	i.Use(stdlib.Symbols)
 	i.Use(unsafe.Symbols)
@@ -72,14 +74,15 @@ func runCheck(t *testing.T, p string) {
 	}
 
 	// read stdout
-	if err = w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	outInterp, err := ioutil.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res := strings.TrimSpace(string(outInterp)); res != wanted {
+	//if err = w.Close(); err != nil {
+	//	t.Fatal(err)
+	//}
+	//outInterp, err := ioutil.ReadAll(r)
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//if res := strings.TrimSpace(string(outInterp)); res != wanted {
+	if res := strings.TrimSpace(stdout.String()); res != wanted {
 		t.Errorf("\ngot:  %q,\nwant: %q", res, wanted)
 	}
 }

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -43,12 +43,6 @@ func runCheck(t *testing.T, p string) {
 	}
 	wanted = strings.TrimSpace(wanted)
 
-	// catch stdout
-	//backupStdout := os.Stdout
-	//defer func() { os.Stdout = backupStdout }()
-	//r, w, _ := os.Pipe()
-	//os.Stdout = w
-
 	if goPath == "" {
 		goPath = build.Default.GOPATH
 	}
@@ -73,15 +67,6 @@ func runCheck(t *testing.T, p string) {
 		t.Fatal(err)
 	}
 
-	// read stdout
-	//if err = w.Close(); err != nil {
-	//	t.Fatal(err)
-	//}
-	//outInterp, err := ioutil.ReadAll(r)
-	//if err != nil {
-	//	t.Fatal(err)
-	//}
-	//if res := strings.TrimSpace(string(outInterp)); res != wanted {
 	if res := strings.TrimSpace(stdout.String()); res != wanted {
 		t.Errorf("\ngot:  %q,\nwant: %q", res, wanted)
 	}

--- a/interp/run.go
+++ b/interp/run.go
@@ -555,13 +555,14 @@ func _print(n *node) {
 	for i, c := range child {
 		values[i] = genValue(c)
 	}
+	out := n.interp.stdout
 
 	genBuiltinDeferWrapper(n, values, nil, func(args []reflect.Value) []reflect.Value {
 		for i, value := range args {
 			if i > 0 {
-				fmt.Printf(" ")
+				fmt.Fprintf(out, " ")
 			}
-			fmt.Printf("%v", value)
+			fmt.Fprintf(out, "%v", value)
 		}
 		return nil
 	})
@@ -573,15 +574,16 @@ func _println(n *node) {
 	for i, c := range child {
 		values[i] = genValue(c)
 	}
+	out := n.interp.stdout
 
 	genBuiltinDeferWrapper(n, values, nil, func(args []reflect.Value) []reflect.Value {
 		for i, value := range args {
 			if i > 0 {
-				fmt.Printf(" ")
+				fmt.Fprintf(out, " ")
 			}
-			fmt.Printf("%v", value)
+			fmt.Fprintf(out, "%v", value)
 		}
-		fmt.Println("")
+		fmt.Fprintln(out, "")
 		return nil
 	})
 }


### PR DESCRIPTION
The goal is to provide greater control of input, output and error
streams of the interpreter. It is now possible to specify those
as options when creating a new interpreter. The provided values
are propagated to relevant stdlib symbols (i.e fmt.Print, etc).
Care is taken to not update the global variables os.Stdout, os.Stdin
and os.Stderr, as to not interfere with the host process.

The REPL function is now simplified. The deprecated version is removed.

The tests are updated to take advantage of the simplified access
to the interpreter output and errors.

Fixes #752.