### PR TITLE
interp: fix data races

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -319,9 +319,9 @@ func initUniverse() *scope {
 		"uintptr":     {kind: typeSym, typ: &itype{cat: uintptrT, name: "uintptr"}},
 
 		// predefined Go constants
-		"false": {kind: constSym, typ: untypedBool, rval: reflect.ValueOf(false)},
-		"true":  {kind: constSym, typ: untypedBool, rval: reflect.ValueOf(true)},
-		"iota":  {kind: constSym, typ: untypedInt},
+		"false": {kind: constSym, typ: untypedBool(), rval: reflect.ValueOf(false)},
+		"true":  {kind: constSym, typ: untypedBool(), rval: reflect.ValueOf(true)},
+		"iota":  {kind: constSym, typ: untypedInt()},
 
 		// predefined Go zero value
 		"nil": {typ: &itype{cat: nilT, untyped: true}},
@@ -561,8 +561,7 @@ func (interp *Interpreter) Use(values Exports) {
 		}
 
 		if interp.binPkg[k] == nil {
-			interp.binPkg[k] = v
-			continue
+			interp.binPkg[k] = make(map[string]reflect.Value)
 		}
 
 		for s, sym := range v {
@@ -571,7 +570,7 @@ func (interp *Interpreter) Use(values Exports) {
 	}
 
 	// Checks if input values correspond to stdlib packages by looking for one
-	// well knwonw stdlib package path.
+	// well known stdlib package path.
 	if _, ok := values["fmt"]; ok {
 		fixStdio(interp)
 	}

--- a/interp/testdata/concurrent/hello1.go
+++ b/interp/testdata/concurrent/hello1.go
@@ -1,0 +1,10 @@
+package main
+
+import "time"
+
+func main() {
+	go func() {
+		time.Sleep(3 * time.Second)
+		println("hello world1")
+	}()
+}

--- a/interp/testdata/concurrent/hello2.go
+++ b/interp/testdata/concurrent/hello2.go
@@ -1,0 +1,10 @@
+package main
+
+import "time"
+
+func main() {
+	go func() {
+		time.Sleep(3 * time.Second)
+		println("hello world2")
+	}()
+}

--- a/interp/type.go
+++ b/interp/type.go
@@ -125,14 +125,12 @@ type itype struct {
 	scope       *scope        // type declaration scope (in case of re-parse incomplete type)
 }
 
-var (
-	untypedBool    = &itype{cat: boolT, name: "bool", untyped: true}
-	untypedString  = &itype{cat: stringT, name: "string", untyped: true}
-	untypedRune    = &itype{cat: int32T, name: "int32", untyped: true}
-	untypedInt     = &itype{cat: intT, name: "int", untyped: true}
-	untypedFloat   = &itype{cat: float64T, name: "float64", untyped: true}
-	untypedComplex = &itype{cat: complex128T, name: "complex128", untyped: true}
-)
+func untypedBool() *itype    { return &itype{cat: boolT, name: "bool", untyped: true} }
+func untypedString() *itype  { return &itype{cat: stringT, name: "string", untyped: true} }
+func untypedRune() *itype    { return &itype{cat: int32T, name: "int32", untyped: true} }
+func untypedInt() *itype     { return &itype{cat: intT, name: "int", untyped: true} }
+func untypedFloat() *itype   { return &itype{cat: float64T, name: "float64", untyped: true} }
+func untypedComplex() *itype { return &itype{cat: complex128T, name: "complex128", untyped: true} }
 
 // nodeType returns a type definition for the corresponding AST subtree.
 func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
@@ -221,24 +219,24 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 		switch v := n.rval.Interface().(type) {
 		case bool:
 			n.rval = reflect.ValueOf(constant.MakeBool(v))
-			t = untypedBool
+			t = untypedBool()
 		case rune:
 			// It is impossible to work out rune const literals in AST
 			// with the correct type so we must make the const type here.
 			n.rval = reflect.ValueOf(constant.MakeInt64(int64(v)))
-			t = untypedRune
+			t = untypedRune()
 		case constant.Value:
 			switch v.Kind() {
 			case constant.Bool:
-				t = untypedBool
+				t = untypedBool()
 			case constant.String:
-				t = untypedString
+				t = untypedString()
 			case constant.Int:
-				t = untypedInt
+				t = untypedInt()
 			case constant.Float:
-				t = untypedFloat
+				t = untypedFloat()
 			case constant.Complex:
-				t = untypedComplex
+				t = untypedComplex()
 			default:
 				err = n.cfgErrorf("missing support for type %v", n.rval)
 			}
@@ -299,7 +297,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 					case isFloat64(t0) && isFloat64(t1):
 						t = sc.getType("complex128")
 					case nt0.untyped && isNumber(t0) && nt1.untyped && isNumber(t1):
-						t = untypedComplex
+						t = untypedComplex()
 					case nt0.untyped && isFloat32(t1) || nt1.untyped && isFloat32(t0):
 						t = sc.getType("complex64")
 					case nt0.untyped && isFloat64(t1) || nt1.untyped && isFloat64(t0):
@@ -1302,6 +1300,7 @@ func exportName(s string) string {
 }
 
 var (
+	// TODO(mpl): generators.
 	interf   = reflect.TypeOf((*interface{})(nil)).Elem()
 	constVal = reflect.TypeOf((*constant.Value)(nil)).Elem()
 )


### PR DESCRIPTION
This change fixes two distinct data races:

1) some global vars of type *itype of the interp package are actually
mutated during the lifecycle of an Interpreter. Even worse: if more than
one Interpreter instance are created and used at a given time, they are
actually racing each other for these global vars.
Therefore, this change replaces these global vars with generator
functions that create the needed type on the fly.

2) the symbols given as argument of Interpreter.Use were directly copied
as reference (since they're maps) when mapped inside an Interpreter
instance. Since the usual case is to give the symbols from the stdlib
package, it means when the interpreter mutates its own symbols in
fixStdio, it would actually mutate the corresponding global vars of the
stdlib package. Again, this is at least racy as soon as several
instances of an Intepreter are concurrently running.
This change fixes the race by making sure Interpreter.Use actually
copies the symbol values instead of copying the references.