### PR TITLE
interp: fix data race for composite literal creation

### DIFF
--- a/interp/testdata/concurrent/composite/composite_lit.go
+++ b/interp/testdata/concurrent/composite/composite_lit.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"time"
+)
+
+type foo struct {
+	bar string
+}
+
+func main() {
+	for i := 0; i < 2; i++ {
+		go func() {
+			a := foo{"hello"}
+			println(a)
+		}()
+	}
+	time.Sleep(time.Second)
+}

--- a/interp/testdata/concurrent/composite/composite_sparse.go
+++ b/interp/testdata/concurrent/composite/composite_sparse.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"time"
+)
+
+type foo struct {
+	bar string
+}
+
+func main() {
+	for i := 0; i < 2; i++ {
+		go func() {
+			a := foo{bar: "hello"}
+			println(a)
+		}()
+	}
+	time.Sleep(time.Second)
+}

--- a/interp/type.go
+++ b/interp/type.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"sync"
 )
 
 // tcat defines interpreter type categories.
@@ -104,6 +105,7 @@ type structField struct {
 
 // itype defines the internal representation of types in the interpreter.
 type itype struct {
+	mu          *sync.Mutex
 	cat         tcat          // Type category
 	field       []structField // Array of struct fields if structT or interfaceT
 	key         *itype        // Type of key element if MapT or nil


### PR DESCRIPTION
This change fixes two data races related to composite literal creation.

The first one isn't controversial as it is just about initializing the
variable that contains the values in the right place, i.e. within the
n.exec, so that this variable is local to each potential goroutine,
instead of being racily shared by all goroutines.

The second one is more worrying, i.e. having to protect the node typ
with a mutex, because a call to func (t *itype) refType actually
modifies the itype itself, which means it is not concurrent safe.
The change seems to work, and does not seem to introduce regression, but
it is still a concern as it probably is a sign that more similar
guarding has to be done in several other places.